### PR TITLE
Add support for read-only lyrics via API.

### DIFF
--- a/api/app/Database/Doctrine/Mappings/LyricsMapping.php
+++ b/api/app/Database/Doctrine/Mappings/LyricsMapping.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Database\Doctrine\Mappings;
+
+use App\Entities\{Lyrics, Track};
+use LaravelDoctrine\Fluent\{EntityMapping, Fluent};
+
+class LyricsMapping extends EntityMapping
+{
+    public function mapFor()
+    {
+        return Lyrics::class;
+    }
+
+    public function map(Fluent $map)
+    {
+        $map->uuidPrimaryKey();
+        $map->manyToOne(Track::class, 'track');
+        $map->text('content');
+        $map->timestamps();
+    }
+}

--- a/api/app/Database/Doctrine/Mappings/TrackMapping.php
+++ b/api/app/Database/Doctrine/Mappings/TrackMapping.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Database\Doctrine\Mappings;
 
 use App\Entities\Album;
+use App\Entities\Lyrics;
 use App\Entities\Reciter;
 use App\Entities\Track;
 use LaravelDoctrine\Fluent\{EntityMapping, Fluent};
@@ -20,7 +21,7 @@ class TrackMapping extends EntityMapping
     {
         $map->uuidPrimaryKey();
         $map->belongsTo(Album::class, 'album')->inversedBy('tracks');
-        $map->belongsTo(Reciter::class, 'reciter');
+        $map->oneToOne(Lyrics::class, 'lyrics');
         $map->string('title');
         $map->string('slug')->length(191);
         $map->unique(['album_id', 'slug'])->name('unique_album_track_slug');

--- a/api/app/Entities/Lyrics.php
+++ b/api/app/Entities/Lyrics.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entities;
+
+use App\Entities\Behaviors\HasTimestamps;
+use App\Entities\Contracts\{Entity, TimestampedEntity};
+use Ramsey\Uuid\{Uuid, UuidInterface};
+use Zain\LaravelDoctrine\Jetpack\Serializer\SerializesAttributes;
+
+class Lyrics implements Entity, TimestampedEntity
+{
+    use HasTimestamps;
+    use SerializesAttributes;
+
+    private UuidInterface $id;
+    private Track $track;
+    private string $content;
+
+    public function __construct(Track $track, string $content)
+    {
+        $this->id = Uuid::uuid1();
+        $this->track = $track;
+        $this->content = $content;
+    }
+
+    public function getId(): string
+    {
+        return $this->id->toString();
+    }
+
+    public function getTrack(): Track
+    {
+        return $this->track;
+    }
+
+    public function getContent(): string
+    {
+        return $this->content;
+    }
+}

--- a/api/app/Entities/Track.php
+++ b/api/app/Entities/Track.php
@@ -16,16 +16,15 @@ class Track implements Entity, TimestampedEntity
     use SerializesAttributes;
 
     private UuidInterface $id;
-    private Reciter $reciter;
     private Album $album;
     private string $title;
     private string $slug;
+    private ?Lyrics $lyrics = null;
 
     public function __construct(Album $album, string $title)
     {
         $this->id = Uuid::uuid1();
         $this->album = $album;
-        $this->reciter = $album->getReciter();
         $this->title = $title;
         // TODO - This may need to take uniqueness into account?
         $this->slug = Str::slug($title);
@@ -38,7 +37,7 @@ class Track implements Entity, TimestampedEntity
 
     public function getReciter(): Reciter
     {
-        return $this->reciter;
+        return $this->getAlbum()->getReciter();
     }
 
     public function getAlbum(): Album
@@ -54,5 +53,15 @@ class Track implements Entity, TimestampedEntity
     public function getSlug(): string
     {
         return $this->slug;
+    }
+
+    public function getLyrics(): ?Lyrics
+    {
+        return $this->lyrics;
+    }
+
+    public function replaceLyrics(Lyrics $lyrics): void
+    {
+        $this->lyrics = $lyrics;
     }
 }

--- a/api/app/Http/Transformers/LyricsTransformer.php
+++ b/api/app/Http/Transformers/LyricsTransformer.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Transformers;
+
+use App\Entities\Lyrics;
+
+class LyricsTransformer extends Transformer
+{
+    public function toArray(Lyrics $lyrics): array
+    {
+        return [
+            'id' => $lyrics->getId(),
+            'trackId' => $lyrics->getTrack()->getId(),
+            'content' => $lyrics->getContent(),
+            $this->timestamps($lyrics),
+        ];
+    }
+}

--- a/api/app/Http/Transformers/TrackTransformer.php
+++ b/api/app/Http/Transformers/TrackTransformer.php
@@ -6,10 +6,11 @@ namespace App\Http\Transformers;
 
 use App\Entities\Track;
 use League\Fractal\Resource\Item;
+use League\Fractal\Resource\ResourceInterface;
 
 class TrackTransformer extends Transformer
 {
-    protected $availableIncludes = ['reciter', 'album'];
+    protected $availableIncludes = ['reciter', 'album', 'lyrics'];
 
     public function toArray(Track $track): array
     {
@@ -32,5 +33,14 @@ class TrackTransformer extends Transformer
     public function includeAlbum(Track $track): Item
     {
         return $this->item($track->getAlbum(), new AlbumTransformer());
+    }
+
+    public function includeLyrics(Track $track): ?ResourceInterface
+    {
+        if (($lyrics = $track->getLyrics()) === null) {
+            return $this->null();
+        }
+
+        return $this->item($lyrics, new LyricsTransformer());
     }
 }

--- a/api/app/Http/Transformers/Transformer.php
+++ b/api/app/Http/Transformers/Transformer.php
@@ -5,6 +5,7 @@ namespace App\Http\Transformers;
 use App\Entities\Contracts\TimestampedEntity;
 use Illuminate\Http\Resources\ConditionallyLoadsAttributes;
 use Illuminate\Http\Resources\MergeValue;
+use League\Fractal\Resource\Primitive;
 use League\Fractal\TransformerAbstract;
 
 abstract class Transformer extends TransformerAbstract
@@ -35,5 +36,10 @@ abstract class Transformer extends TransformerAbstract
             'createdAt' => $this->dateTime($entity->getCreatedAt()),
             'updatedAt' => $this->dateTime($entity->getUpdatedAt()),
         ]);
+    }
+
+    protected function null(): Primitive
+    {
+        return $this->primitive(null);
     }
 }

--- a/api/composer.lock
+++ b/api/composer.lock
@@ -4957,16 +4957,16 @@
         },
         {
             "name": "zain/laravel-doctrine-jetpack",
-            "version": "v0.5",
+            "version": "v0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/szainmehdi/laravel-doctrine-jetpack.git",
-                "reference": "e8fac0b69c607d6d22f8b3c19bbf163fd3ee75ce"
+                "reference": "0c797e3cb11a803f040898d8d04a724fa67e22f5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/szainmehdi/laravel-doctrine-jetpack/zipball/e8fac0b69c607d6d22f8b3c19bbf163fd3ee75ce",
-                "reference": "e8fac0b69c607d6d22f8b3c19bbf163fd3ee75ce",
+                "url": "https://api.github.com/repos/szainmehdi/laravel-doctrine-jetpack/zipball/0c797e3cb11a803f040898d8d04a724fa67e22f5",
+                "reference": "0c797e3cb11a803f040898d8d04a724fa67e22f5",
                 "shasum": ""
             },
             "require": {
@@ -5018,7 +5018,7 @@
                 "laravel",
                 "mapping"
             ],
-            "time": "2020-02-10T02:35:22+00:00"
+            "time": "2020-02-13T02:42:49+00:00"
         }
     ],
     "packages-dev": [

--- a/api/database/migrations/doctrine/Version20200213031919.php
+++ b/api/database/migrations/doctrine/Version20200213031919.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Database\Migrations\Doctrine;
+
+use Doctrine\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema as Schema;
+
+class Version20200213031919 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('CREATE TABLE lyrics (id CHAR(36) NOT NULL COMMENT \'(DC2Type:uuid)\', track_id CHAR(36) NOT NULL COMMENT \'(DC2Type:uuid)\', content LONGTEXT NOT NULL, created_at DATETIME NOT NULL, updated_at DATETIME NOT NULL, INDEX IDX_3BDA6C665ED23C43 (track_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE lyrics ADD CONSTRAINT FK_3BDA6C665ED23C43 FOREIGN KEY (track_id) REFERENCES tracks (id)');
+        $this->addSql('ALTER TABLE tracks DROP FOREIGN KEY FK_246D2A2EDEDF9489');
+        $this->addSql('DROP INDEX IDX_246D2A2EDEDF9489 ON tracks');
+        $this->addSql('ALTER TABLE tracks ADD lyric_id CHAR(36) DEFAULT NULL COMMENT \'(DC2Type:uuid)\', DROP reciter_id');
+        $this->addSql('ALTER TABLE tracks ADD CONSTRAINT FK_246D2A2EF9CD025C FOREIGN KEY (lyric_id) REFERENCES lyrics (id)');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_246D2A2EF9CD025C ON tracks (lyric_id)');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE tracks DROP FOREIGN KEY FK_246D2A2EF9CD025C');
+        $this->addSql('DROP TABLE lyrics');
+        $this->addSql('DROP INDEX UNIQ_246D2A2EF9CD025C ON tracks');
+        $this->addSql('ALTER TABLE tracks ADD reciter_id CHAR(36) CHARACTER SET utf8mb4 NOT NULL COLLATE `utf8mb4_unicode_ci` COMMENT \'(DC2Type:uuid)\', DROP lyric_id');
+        $this->addSql('ALTER TABLE tracks ADD CONSTRAINT FK_246D2A2EDEDF9489 FOREIGN KEY (reciter_id) REFERENCES reciters (id)');
+        $this->addSql('CREATE INDEX IDX_246D2A2EDEDF9489 ON tracks (reciter_id)');
+    }
+}

--- a/api/database/seeds/TestDataSeeder.php
+++ b/api/database/seeds/TestDataSeeder.php
@@ -2,6 +2,7 @@
 
 use App\Database\Doctrine\EntityManager;
 use App\Entities\Album;
+use App\Entities\Lyrics;
 use App\Entities\Reciter;
 use App\Entities\Track;
 use Illuminate\Database\Seeder;
@@ -19,7 +20,15 @@ class TestDataSeeder extends Seeder
         $album = new Album($reciter, 'Ya Hussain', '2019');
         $track = new Track($album, 'Ya Ali Ya Hussain');
 
-        $em->persist($reciter, $album, $track);
+        // Lyrics have to be handled a bit differently.
+        // The idea is that many lyrics objects can stand own their
+        // own with a reference back to the track they're related to.
+        // But the Track object only cares about one lyric object.
+        // This association must be made separately.
+        $lyrics = new Lyrics($track, 'Hello World');
+        $track->replaceLyrics($lyrics);
+
+        $em->persist($reciter, $album, $track, $lyrics);
         app('em')->flush();
     }
 }


### PR DESCRIPTION
Closes #4

You can now visit a route like
```
https://api.nawhas.test/v1/reciters/nadeem-sarwar/albums/2019/tracks/ya-ali-ya-hussain?include=lyrics
```

And get the lyrics back:
```json
{
  "id": "c6babe82-4e12-11ea-b3ef-0242ac1a0004",
  "reciterId": "c6b91c3a-4e12-11ea-bd0f-0242ac1a0004",
  "albumId": "c6b9cc02-4e12-11ea-9b9b-0242ac1a0004",
  "title": "Ya Ali Ya Hussain",
  "slug": "ya-ali-ya-hussain",
  "year": "2019",
  "createdAt": "2020-02-13T03:41:54+00:00",
  "updatedAt": "2020-02-13T03:41:54+00:00",
  "lyrics": {
    "id": "c6bb25f2-4e12-11ea-8bba-0242ac1a0004",
    "trackId": "c6babe82-4e12-11ea-b3ef-0242ac1a0004",
    "content": "Hello World",
    "createdAt": "2020-02-13T03:41:54+00:00",
    "updatedAt": "2020-02-13T03:41:54+00:00"
  }
}
```