### PR TITLE
Separate out provider and type for media entity using enums

### DIFF
--- a/api/app/Database/Doctrine/Mappings/MediaMapping.php
+++ b/api/app/Database/Doctrine/Mappings/MediaMapping.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Database\Doctrine\Mappings;
 
 use App\Entities\Media;
+use App\Enum\MediaProvider;
+use App\Enum\MediaType;
 use LaravelDoctrine\Fluent\{EntityMapping, Fluent};
 
 class MediaMapping extends EntityMapping
@@ -17,7 +19,8 @@ class MediaMapping extends EntityMapping
     public function map(Fluent $map)
     {
         $map->uuidPrimaryKey();
-        $map->string('type')->index();
+        $map->field(MediaType::class, 'type')->index();
+        $map->field(MediaProvider::class, 'provider')->index();
         $map->string('uri');
         $map->timestamps();
     }

--- a/api/app/Entities/Media.php
+++ b/api/app/Entities/Media.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Entities;
 
 use App\Entities\Behaviors\HasTimestamps;
+use App\Enum\MediaProvider;
+use App\Enum\MediaType;
 use App\Entities\Contracts\{Entity, TimestampedEntity};
 use Ramsey\Uuid\{Uuid, UuidInterface};
 use Zain\LaravelDoctrine\Jetpack\Serializer\SerializesAttributes;
@@ -14,22 +16,22 @@ class Media implements Entity, TimestampedEntity
     use HasTimestamps;
     use SerializesAttributes;
 
-    public const TYPE_AUDIO_FILE = 'audio-file';
-
     private UuidInterface $id;
-    private string $type;
+    private MediaType $type;
+    private MediaProvider $provider;
     private string $uri;
 
-    public function __construct(string $type, string $uri)
+    public function __construct(MediaType $type, MediaProvider $provider, string $uri)
     {
         $this->id = Uuid::uuid1();
         $this->type = $type;
+        $this->provider = $provider;
         $this->uri = $uri;
     }
 
     public static function audioFile(string $uri): self
     {
-        return new self(self::TYPE_AUDIO_FILE, $uri);
+        return new self(MediaType::AUDIO(), MediaProvider::FILE(), $uri);
     }
 
     public function getId(): string
@@ -37,9 +39,14 @@ class Media implements Entity, TimestampedEntity
         return $this->id->toString();
     }
 
-    public function getType(): string
+    public function getType(): MediaType
     {
         return $this->type;
+    }
+
+    public function getProvider(): MediaProvider
+    {
+        return $this->provider;
     }
 
     public function getUri(): string

--- a/api/app/Enum/MediaProvider.php
+++ b/api/app/Enum/MediaProvider.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enum;
+
+use MyCLabs\Enum\Enum;
+
+/**
+ * @method static self FILE()
+ * @method static self SPOTIFY()
+ * @method static self YOUTUBE()
+ */
+class MediaProvider extends Enum
+{
+    public const FILE = 'file';
+    public const SPOTIFY = 'spotify';
+    public const YOUTUBE = 'youtube';
+}

--- a/api/app/Enum/MediaType.php
+++ b/api/app/Enum/MediaType.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enum;
+
+use MyCLabs\Enum\Enum;
+
+/**
+ * @method static self AUDIO()
+ * @method static self VIDEO()
+ */
+class MediaType extends Enum
+{
+    public const AUDIO = 'audio';
+    public const VIDEO = 'video';
+}

--- a/api/app/Http/Transformers/MediaTransformer.php
+++ b/api/app/Http/Transformers/MediaTransformer.php
@@ -13,7 +13,8 @@ class MediaTransformer extends Transformer
         return [
             'id' => $media->getId(),
             'uri' => $media->getUri(),
-            'type' => $media->getType(),
+            'type' => $media->getType()->getValue(),
+            'provider' => $media->getProvider()->getValue(),
             $this->timestamps($media),
         ];
     }

--- a/api/app/Providers/DoctrineServiceProvider.php
+++ b/api/app/Providers/DoctrineServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Providers;
 
+use Acelaya\Doctrine\Type\PhpEnumType;
 use App\Repositories\AlbumRepository;
 use App\Repositories\Doctrine\DoctrineAlbumRepository;
 use App\Repositories\Doctrine\DoctrineReciterRepository;
@@ -12,6 +13,9 @@ use App\Repositories\ReciterRepository;
 use App\Repositories\TrackRepository;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Support\ServiceProvider;
+use MyCLabs\Enum\Enum;
+use ReflectionClass;
+use Symfony\Component\Finder\Finder;
 
 class DoctrineServiceProvider extends ServiceProvider
 {
@@ -21,6 +25,7 @@ class DoctrineServiceProvider extends ServiceProvider
     public function register()
     {
          $this->bindRepositories();
+         $this->registerEnumTypes();
     }
 
     /**
@@ -31,5 +36,29 @@ class DoctrineServiceProvider extends ServiceProvider
         $this->app->bind(ReciterRepository::class, DoctrineReciterRepository::class);
         $this->app->bind(AlbumRepository::class, DoctrineAlbumRepository::class);
         $this->app->bind(TrackRepository::class, DoctrineTrackRepository::class);
+    }
+
+    private function registerEnumTypes(): void
+    {
+        $finder = new Finder();
+
+        $finder->files()->name('*.php')->in(__DIR__ . '/../Enum/');
+
+        foreach ($finder as $file) {
+            /** @var \Symfony\Component\Finder\SplFileInfo $file **/
+            $ns = 'App\Enum';
+
+            if ($relativePath = $file->getRelativePath()) {
+                $ns .= '\\' . strtr($relativePath, '/', '\\');
+            }
+
+            $className = $ns . '\\' . $file->getBasename('.php');
+
+            $class = new ReflectionClass($className);
+
+            if ($class->isSubclassOf(Enum::class) && !$class->isAbstract() && !PhpEnumType::hasType($className)) {
+                PhpEnumType::registerEnumType($className);
+            }
+        }
     }
 }

--- a/api/composer.json
+++ b/api/composer.json
@@ -5,6 +5,7 @@
     "license": "MIT",
     "require": {
         "php": "7.4.*",
+        "acelaya/doctrine-enum-type": "^2.3",
         "beberlei/doctrineextensions": "^1.2",
         "fideloper/proxy": "^4.0",
         "gedmo/doctrine-extensions": "^2.4",
@@ -17,6 +18,7 @@
         "laravel/tinker": "^2.0",
         "league/flysystem-aws-s3-v3": "^1.0",
         "league/fractal": "^0.19.2",
+        "myclabs/php-enum": "^1.7",
         "ramsey/uuid-doctrine": "^1.6",
         "spatie/laravel-cors": "^1.6",
         "zain/laravel-doctrine-jetpack": "*"

--- a/api/composer.lock
+++ b/api/composer.lock
@@ -4,8 +4,57 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b560181e77bc1c1736b9c604f401613f",
+    "content-hash": "a5a70c4d5853b3b883b791a90eea02f4",
     "packages": [
+        {
+            "name": "acelaya/doctrine-enum-type",
+            "version": "v2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/acelaya/doctrine-enum-type.git",
+                "reference": "4db8de01d8044446c6e5ec4958e082a2be65000c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/acelaya/doctrine-enum-type/zipball/4db8de01d8044446c6e5ec4958e082a2be65000c",
+                "reference": "4db8de01d8044446c6e5ec4958e082a2be65000c",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/dbal": "^2.6",
+                "myclabs/php-enum": "^1.4",
+                "php": "^7.2"
+            },
+            "require-dev": {
+                "infection/infection": "^0.15.0",
+                "phpstan/phpstan": "^0.12.0",
+                "phpunit/phpunit": "^8.0",
+                "shlinkio/php-coding-standard": "~2.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Acelaya\\Doctrine\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alejandro Celaya",
+                    "email": "alejandro@alejandrocelaya.com"
+                }
+            ],
+            "description": "A custom Doctrine type that maps column values to enum objects using myclabs/php-enum",
+            "keywords": [
+                "doctrine",
+                "enum",
+                "type"
+            ],
+            "time": "2019-12-14T10:50:45+00:00"
+        },
         {
             "name": "aws/aws-sdk-php",
             "version": "3.133.16",
@@ -2900,6 +2949,52 @@
                 "jsonpath"
             ],
             "time": "2019-12-30T18:03:34+00:00"
+        },
+        {
+            "name": "myclabs/php-enum",
+            "version": "1.7.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/php-enum.git",
+                "reference": "5f36467c7a87e20fbdc51e524fd8f9d1de80187c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/php-enum/zipball/5f36467c7a87e20fbdc51e524fd8f9d1de80187c",
+                "reference": "5f36467c7a87e20fbdc51e524fd8f9d1de80187c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7",
+                "squizlabs/php_codesniffer": "1.*",
+                "vimeo/psalm": "^3.8"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "MyCLabs\\Enum\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP Enum contributors",
+                    "homepage": "https://github.com/myclabs/php-enum/graphs/contributors"
+                }
+            ],
+            "description": "PHP Enum implementation",
+            "homepage": "http://github.com/myclabs/php-enum",
+            "keywords": [
+                "enum"
+            ],
+            "time": "2020-02-14T08:15:52+00:00"
         },
         {
             "name": "nesbot/carbon",

--- a/api/database/migrations/doctrine/Version20200218153256.php
+++ b/api/database/migrations/doctrine/Version20200218153256.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Migrations\Doctrine;
+
+use Doctrine\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema as Schema;
+
+class Version20200218153256 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE media ADD provider VARCHAR(255) NOT NULL COMMENT \'(DC2Type:App\\\\Enum\\\\MediaProvider)\', CHANGE type type VARCHAR(255) NOT NULL COMMENT \'(DC2Type:App\\\\Enum\\\\MediaType)\'');
+        $this->addSql('CREATE INDEX media_provider_index ON media (provider)');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('DROP INDEX media_provider_index ON media');
+        $this->addSql('ALTER TABLE media DROP provider, CHANGE type type VARCHAR(255) CHARACTER SET utf8mb4 NOT NULL COLLATE `utf8mb4_unicode_ci`');
+    }
+}


### PR DESCRIPTION
Response looks like this now:
```json
{
  "id": "a1821f3a-51a9-11ea-a146-0242ac1a0004",
  "reciterId": "a1601d40-51a9-11ea-af73-0242ac1a0004",
  "albumId": "a175d5f4-51a9-11ea-a03c-0242ac1a0004",
  "title": "Taqseer Te Nai Koi Syedasdi",
  "slug": "taqseer-te-nai-koi-syedasdi",
  "year": "2009",
  "createdAt": "2020-02-17T17:19:18+00:00",
  "updatedAt": "2020-02-18T01:59:13+00:00",
  "media": {
    "data": [
      {
        "id": "8eb5da3e-51f1-11ea-bb42-0242c0a85004",
        "uri": "https://s3.us-east-2.amazonaws.com/zain.local.nawhas/reciters/adeem-raza-messum-zaidi/albums/2009/tracks/taqseer-te-nai-koi-syedasdi.mp3",
        "type": "audio",
        "provider": "file",
        "createdAt": "2020-02-18T01:54:11+00:00",
        "updatedAt": "2020-02-18T01:54:11+00:00"
      }
    ]
  }
}
```