### PR TITLE
[Feature] Adding repeat to audio player

### DIFF
--- a/web/src/components/audio-player/AudioPlayer.vue
+++ b/web/src/components/audio-player/AudioPlayer.vue
@@ -49,14 +49,8 @@
           </div>
         </div>
         <div class="player-actions">
-          <v-btn @click="toggleRepeat" icon :color="repeat ? 'deep-orange' : 'secondary'">
-            <v-icon v-if="repeat === null || repeat === 'all'">repeat</v-icon>
-            <v-icon v-else>repeat_one</v-icon>
-          </v-btn>
           <v-btn icon
             v-if="!minimized"
-            :height="playbackControlSizes.standard.button"
-            :width="playbackControlSizes.standard.button"
             @click="toggleShuffle"
             :color="shuffled ? 'deep-orange' : 'secondary'"
           >
@@ -93,6 +87,13 @@
             :disabled="!hasNext"
           >
             <v-icon :size="playbackControlSizes.standard.icon">skip_next</v-icon>
+          </v-btn>
+          <v-btn @click="toggleRepeat"
+                 icon
+                 v-if="!minimized"
+                 :color="repeat ? 'deep-orange' : 'secondary'">
+            <v-icon v-if="repeat === null || repeat === 'all'">repeat</v-icon>
+            <v-icon v-else>repeat_one</v-icon>
           </v-btn>
           <v-menu
             v-if="minimized"
@@ -727,7 +728,7 @@ $duration: 680ms;
   }
   .player-actions {
     margin: auto;
-    justify-content: center;
+    justify-content: space-around;
     display: flex;
     align-items: center;
   }
@@ -842,7 +843,7 @@ $duration: 680ms;
       align-items: center;
       justify-content: space-between;
       width: 100%;
-      padding: 0 24px;
+      padding: 0;
     }
   }
 }

--- a/web/src/store/modules/player.ts
+++ b/web/src/store/modules/player.ts
@@ -1,5 +1,6 @@
 export type CurrentTrackRef = number|null;
 export type TrackQueue = Array<QueuedTrack>;
+export type RepeatType = null|'one'|'all';
 export interface QueuedTrack {
   track: object;
   id: string;
@@ -38,6 +39,7 @@ export interface PlayerState {
   seek: number;
   duration: number;
   isShuffled: boolean;
+  repeat: RepeatType;
 }
 
 const state: PlayerState = {
@@ -47,6 +49,7 @@ const state: PlayerState = {
   queue: [],
   shuffled: [],
   isShuffled: false,
+  repeat: null,
 };
 
 const getters = {
@@ -181,6 +184,19 @@ const mutations = {
     state.current = payload.current;
     state.shuffled = payload.shuffled;
     state.isShuffled = payload.isShuffled;
+  },
+  TOGGLE_REPEAT(state: PlayerState) {
+    let repeat: RepeatType = null;
+    if (state.repeat === null) {
+      repeat = 'one';
+    }
+    if (state.repeat === 'one') {
+      repeat = 'all';
+    }
+    if (state.repeat === 'all') {
+      repeat = null;
+    }
+    state.repeat = repeat;
   },
 };
 

--- a/web/src/store/modules/player.ts
+++ b/web/src/store/modules/player.ts
@@ -188,12 +188,12 @@ const mutations = {
   TOGGLE_REPEAT(state: PlayerState) {
     let repeat: RepeatType = null;
     if (state.repeat === null) {
-      repeat = 'one';
-    }
-    if (state.repeat === 'one') {
       repeat = 'all';
     }
     if (state.repeat === 'all') {
+      repeat = 'one';
+    }
+    if (state.repeat === 'one') {
       repeat = null;
     }
     state.repeat = repeat;


### PR DESCRIPTION
Closes #107 

User can do the following

repeat off -> The audio will not loop
repeat all -> At the end of the queue, the player will again play the first track
repeat one -> The current track will continue to loop