### PR TITLE
Fixed #118

### DIFF
--- a/web/src/views/public/tracks/Show.vue
+++ b/web/src/views/public/tracks/Show.vue
@@ -269,7 +269,7 @@ export default class TrackPage extends Vue {
       });
     }
     await getTracks(reciter, album, {
-      include: 'reciter,lyrics,album,media',
+      include: 'reciter,lyrics,album,media,related',
     }).then((r) => {
       this.albumTracks = r.data.data;
     });


### PR DESCRIPTION
So as part of a previous bug fix we are checking to see if the audio has audio or not. This was picking up from the `related` attributes.
On the tracks page, we were not calling `related` so now making tracks page also pick the `related` attributes such as `lyrics: true, audio: true`

Closes #118 