### PR TITLE
Guard edit routes

### DIFF
--- a/api/app/Http/Kernel.php
+++ b/api/app/Http/Kernel.php
@@ -41,7 +41,7 @@ class Kernel extends HttpKernel
 
         'api' => [
             \Laravel\Airlock\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
-            'throttle:60,1',
+            // 'throttle:60,1', // TODO - Make this work with proxies.
             // TODO - Make this work with lower precedence than the explicit binding
              \App\Http\Middleware\SubstituteDoctrineBindings::class,
         ],

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -31,12 +31,12 @@ Route::prefix('v1')->group(function () {
         Route::get('/', [RecitersController::class, 'index']);
         Route::get('/{reciter}', [RecitersController::class, 'show']);
 
-        if (app()->environment() !== 'production') {
+        Route::middleware('auth:airlock')->group(function () {
             Route::post('/', [RecitersController::class, 'store']);
             Route::patch('/{reciter}', [RecitersController::class, 'update']);
             Route::post('/{reciter}/avatar', [RecitersController::class, 'uploadAvatar']);
             // Route::delete('/{reciter}', [RecitersController::class, 'destroy']);
-        }
+        });
     });
 
     // Reciter Albums
@@ -44,12 +44,12 @@ Route::prefix('v1')->group(function () {
         Route::get('/', [AlbumsController::class, 'index']);
         Route::get('/{album}', [AlbumsController::class, 'show']);
 
-        if (app()->environment() !== 'production') {
+        Route::middleware('auth:airlock')->group(function () {
             Route::post('/', [AlbumsController::class, 'store']);
             Route::patch('/{album}', [AlbumsController::class, 'update']);
             Route::post('/{album}/artwork', [AlbumsController::class, 'uploadArtwork']);
             Route::delete('/{album}', [AlbumsController::class, 'destroy']);
-        }
+        });
     });
 
     // Album Tracks
@@ -57,12 +57,12 @@ Route::prefix('v1')->group(function () {
         Route::get('/', [TracksController::class, 'index']);
         Route::get('/{track}', [TracksController::class, 'show']);
 
-        if (app()->environment() !== 'production') {
+        Route::middleware('auth:airlock')->group(function () {
             Route::post('/', [TracksController::class, 'store']);
             Route::patch('/{track}', [TracksController::class, 'update']);
             Route::post('/{track}/media/audio', [TracksController::class, 'uploadTrackMedia']);
             Route::delete('/{track}', [TracksController::class, 'destroy']);
-        }
+        });
     });
 
     // Popular Routes


### PR DESCRIPTION
This is the easiest way to guard the edit routes.

Also in this PR: disable api rate limiting.