### PR TITLE
Add version number to lyrics.

### DIFF
--- a/api/app/Console/Commands/ImportDataCommand.php
+++ b/api/app/Console/Commands/ImportDataCommand.php
@@ -188,7 +188,7 @@ class ImportDataCommand extends Command
             // Lyrics
             if ($this->source->exists($directory . '/lyrics.txt')) {
                 $text = $this->getLyricsFromFile($directory);
-                $lyrics = new Lyrics($track, $text);
+                $lyrics = new Lyrics($track, $text, Lyrics::V1);
                 $track->replaceLyrics($lyrics);
             }
 

--- a/api/app/Console/Commands/ImportDataCommand.php
+++ b/api/app/Console/Commands/ImportDataCommand.php
@@ -188,7 +188,7 @@ class ImportDataCommand extends Command
             // Lyrics
             if ($this->source->exists($directory . '/lyrics.txt')) {
                 $text = $this->getLyricsFromFile($directory);
-                $lyrics = new Lyrics($track, $text, Lyrics::V1);
+                $lyrics = new Lyrics($track, $text, Lyrics::FORMAT_PLAIN_TEXT);
                 $track->replaceLyrics($lyrics);
             }
 

--- a/api/app/Database/Doctrine/Mappings/LyricsMapping.php
+++ b/api/app/Database/Doctrine/Mappings/LyricsMapping.php
@@ -19,6 +19,7 @@ class LyricsMapping extends EntityMapping
         $map->uuidPrimaryKey();
         $map->manyToOne(Track::class, 'track');
         $map->text('content');
+        $map->smallInteger('version')->unsigned()->default('1');
         $map->timestamps();
     }
 }

--- a/api/app/Database/Doctrine/Mappings/LyricsMapping.php
+++ b/api/app/Database/Doctrine/Mappings/LyricsMapping.php
@@ -19,7 +19,7 @@ class LyricsMapping extends EntityMapping
         $map->uuidPrimaryKey();
         $map->manyToOne(Track::class, 'track');
         $map->text('content');
-        $map->smallInteger('version')->unsigned()->default('1');
+        $map->smallInteger('format')->unsigned()->default('1');
         $map->timestamps();
     }
 }

--- a/api/app/Entities/Lyrics.php
+++ b/api/app/Entities/Lyrics.php
@@ -37,14 +37,14 @@ class Lyrics implements Entity, TimestampedEntity
     private UuidInterface $id;
     private Track $track;
     private string $content;
-    private int $version;
+    private int $format;
 
-    public function __construct(Track $track, string $content, int $version)
+    public function __construct(Track $track, string $content, int $format)
     {
         $this->id = Uuid::uuid1();
         $this->track = $track;
         $this->content = $content;
-        $this->version = $version;
+        $this->format = $format;
     }
 
     public function getId(): string
@@ -62,8 +62,8 @@ class Lyrics implements Entity, TimestampedEntity
         return $this->content;
     }
 
-    public function getVersion(): int
+    public function getFormat(): int
     {
-        return $this->version;
+        return $this->format;
     }
 }

--- a/api/app/Entities/Lyrics.php
+++ b/api/app/Entities/Lyrics.php
@@ -12,10 +12,10 @@ use Zain\LaravelDoctrine\Jetpack\Serializer\SerializesAttributes;
 class Lyrics implements Entity, TimestampedEntity
 {
     /**
-     * Version 1:
+     * Format 1:
      * Flat text document.
      */
-    public const V1 = 1;
+    public const FORMAT_PLAIN_TEXT = 1;
 
     /**
      * Version 2:
@@ -29,7 +29,7 @@ class Lyrics implements Entity, TimestampedEntity
      *   }
      * ]
      */
-    public const V2 = 2;
+    public const FORMAT_JSON_V1 = 2;
 
     use HasTimestamps;
     use SerializesAttributes;

--- a/api/app/Entities/Lyrics.php
+++ b/api/app/Entities/Lyrics.php
@@ -11,18 +11,40 @@ use Zain\LaravelDoctrine\Jetpack\Serializer\SerializesAttributes;
 
 class Lyrics implements Entity, TimestampedEntity
 {
+    /**
+     * Version 1:
+     * Flat text document.
+     */
+    public const V1 = 1;
+
+    /**
+     * Version 2:
+     * JSON document:
+     * [
+     *   {
+     *     "timestamp": int,
+     *     "lines": [
+     *       { "text": string, "repeat": optional<int> }
+     *     ]
+     *   }
+     * ]
+     */
+    public const V2 = 2;
+
     use HasTimestamps;
     use SerializesAttributes;
 
     private UuidInterface $id;
     private Track $track;
     private string $content;
+    private int $version;
 
-    public function __construct(Track $track, string $content)
+    public function __construct(Track $track, string $content, int $version)
     {
         $this->id = Uuid::uuid1();
         $this->track = $track;
         $this->content = $content;
+        $this->version = $version;
     }
 
     public function getId(): string
@@ -38,5 +60,10 @@ class Lyrics implements Entity, TimestampedEntity
     public function getContent(): string
     {
         return $this->content;
+    }
+
+    public function getVersion(): int
+    {
+        return $this->version;
     }
 }

--- a/api/app/Http/Controllers/Api/TracksController.php
+++ b/api/app/Http/Controllers/Api/TracksController.php
@@ -47,7 +47,7 @@ class TracksController extends Controller
         );
 
         if ($request->has('lyrics')) {
-            $track->replaceLyrics(new Lyrics($track, $request->get('lyrics')));
+            $track->replaceLyrics(new Lyrics($track, $request->get('lyrics'), $request->get('version', Lyrics::V1)));
         }
 
         $this->repository->persist($track);
@@ -68,7 +68,7 @@ class TracksController extends Controller
             $track->setTitle($request->get('title'));
         }
         if ($request->has('lyrics')) {
-            $track->replaceLyrics(new Lyrics($track, $request->get('lyrics')));
+            $track->replaceLyrics(new Lyrics($track, $request->get('lyrics'), $request->get('version', Lyrics::V1)));
         }
 
         $this->repository->persist($track);

--- a/api/app/Http/Controllers/Api/TracksController.php
+++ b/api/app/Http/Controllers/Api/TracksController.php
@@ -47,7 +47,7 @@ class TracksController extends Controller
         );
 
         if ($request->has('lyrics')) {
-            $track->replaceLyrics(new Lyrics($track, $request->get('lyrics'), $request->get('version', Lyrics::V1)));
+            $track->replaceLyrics(new Lyrics($track, $request->get('lyrics'), $request->get('format', Lyrics::V1)));
         }
 
         $this->repository->persist($track);
@@ -68,7 +68,7 @@ class TracksController extends Controller
             $track->setTitle($request->get('title'));
         }
         if ($request->has('lyrics')) {
-            $track->replaceLyrics(new Lyrics($track, $request->get('lyrics'), $request->get('version', Lyrics::V1)));
+            $track->replaceLyrics(new Lyrics($track, $request->get('lyrics'), $request->get('format', Lyrics::V1)));
         }
 
         $this->repository->persist($track);

--- a/api/app/Http/Controllers/Api/TracksController.php
+++ b/api/app/Http/Controllers/Api/TracksController.php
@@ -47,7 +47,7 @@ class TracksController extends Controller
         );
 
         if ($request->has('lyrics')) {
-            $track->replaceLyrics(new Lyrics($track, $request->get('lyrics'), $request->get('format', Lyrics::V1)));
+            $track->replaceLyrics(new Lyrics($track, $request->get('lyrics'), $request->get('format', Lyrics::FORMAT_PLAIN_TEXT)));
         }
 
         $this->repository->persist($track);
@@ -68,7 +68,7 @@ class TracksController extends Controller
             $track->setTitle($request->get('title'));
         }
         if ($request->has('lyrics')) {
-            $track->replaceLyrics(new Lyrics($track, $request->get('lyrics'), $request->get('format', Lyrics::V1)));
+            $track->replaceLyrics(new Lyrics($track, $request->get('lyrics'), $request->get('format', Lyrics::FORMAT_PLAIN_TEXT)));
         }
 
         $this->repository->persist($track);

--- a/api/app/Http/Transformers/LyricsTransformer.php
+++ b/api/app/Http/Transformers/LyricsTransformer.php
@@ -14,6 +14,7 @@ class LyricsTransformer extends Transformer
             'id' => $lyrics->getId(),
             'trackId' => $lyrics->getTrack()->getId(),
             'content' => $lyrics->getContent(),
+            'version' => $lyrics->getVersion(),
             $this->timestamps($lyrics),
         ];
     }

--- a/api/app/Http/Transformers/LyricsTransformer.php
+++ b/api/app/Http/Transformers/LyricsTransformer.php
@@ -14,7 +14,7 @@ class LyricsTransformer extends Transformer
             'id' => $lyrics->getId(),
             'trackId' => $lyrics->getTrack()->getId(),
             'content' => $lyrics->getContent(),
-            'version' => $lyrics->getVersion(),
+            'format' => $lyrics->getFormat(),
             $this->timestamps($lyrics),
         ];
     }

--- a/api/database/migrations/doctrine/Version20200331233330.php
+++ b/api/database/migrations/doctrine/Version20200331233330.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Migrations\Doctrine;
+
+use Doctrine\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema as Schema;
+
+class Version20200331233330 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('ALTER TABLE lyrics ADD version SMALLINT DEFAULT 1 NOT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('ALTER TABLE lyrics DROP version');
+    }
+}

--- a/api/database/migrations/doctrine/Version20200403204321.php
+++ b/api/database/migrations/doctrine/Version20200403204321.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Migrations\Doctrine;
+
+use Doctrine\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema as Schema;
+
+class Version20200403204321 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('ALTER TABLE lyrics ADD format SMALLINT DEFAULT 1 NOT NULL');
+        $this->addSql('ALTER TABLE lyrics DROP version');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('ALTER TABLE lyrics ADD version SMALLINT DEFAULT 1 NOT NULL');
+        $this->addSql('ALTER TABLE lyrics DROP format');
+    }
+}

--- a/api/database/seeds/TestDataSeeder.php
+++ b/api/database/seeds/TestDataSeeder.php
@@ -49,7 +49,7 @@ class TestDataSeeder extends Seeder
                 foreach ($a['tracks'] as $t) {
                     $track = new Track($album, $t['title']);
                     if ($t['lyrics']) {
-                        $track->replaceLyrics(new Lyrics($track, $t['lyrics']));
+                        $track->replaceLyrics(new Lyrics($track, $t['lyrics'], Lyrics::V1));
                     }
                     if ($t['audio']) {
                         $track->addAudioFile(Media::audioFile($t['audio']));

--- a/api/database/seeds/TestDataSeeder.php
+++ b/api/database/seeds/TestDataSeeder.php
@@ -49,7 +49,7 @@ class TestDataSeeder extends Seeder
                 foreach ($a['tracks'] as $t) {
                     $track = new Track($album, $t['title']);
                     if ($t['lyrics']) {
-                        $track->replaceLyrics(new Lyrics($track, $t['lyrics'], Lyrics::V1));
+                        $track->replaceLyrics(new Lyrics($track, $t['lyrics'], Lyrics::FORMAT_PLAIN_TEXT));
                     }
                     if ($t['audio']) {
                         $track->addAudioFile(Media::audioFile($t['audio']));


### PR DESCRIPTION
This PR adds a version number to lyrics, which will allow the frontend to handle various types of lyrics content without the need of a database level migration.

A version number in the lyrics object in the track response will provide necessary information to the frontend to handle displaying different types of lyrics content.

<details>
<summary>Example Response</summary>
```json
{
  "id": "8f08f7d0-5ff4-11ea-818c-327c6b7fa86c",
  "reciterId": "4105f6a8-5407-11ea-922c-6eb465563d0f",
  "albumId": "9bb82a98-5ff2-11ea-ad34-327c6b7fa86c",
  "title": "Roti Hai Sakina",
  "slug": "roti-hai-sakina",
  "year": "2019",
  "createdAt": "2020-03-06T21:50:56+00:00",
  "updatedAt": "2020-03-06T22:00:33+00:00",
  "lyrics": {
    "id": "8f090716-5ff4-11ea-8037-327c6b7fa86c",
    "trackId": "8f08f7d0-5ff4-11ea-818c-327c6b7fa86c",
    "content": "Baba Dekho ye Teri Jaan hai\n...",
    "version": 1,
    "createdAt": "2020-03-06T21:50:56+00:00",
    "updatedAt": "2020-03-06T21:50:56+00:00"
  }
}
```
</details>

- **Version 1**  will refer to the original, flat text document.  
- **Version 2**  will refer to the timestampable json structure.

This approach allows for future changes to the document structure without fear of breaking the frontend.

> Note: This approach is not necessarily the one we take. This is one of many possible solutions.