### PR TITLE
Lyrics Refactor

### DIFF
--- a/web/src/components/audio-player/AudioPlayer.vue
+++ b/web/src/components/audio-player/AudioPlayer.vue
@@ -37,12 +37,12 @@
         class="lyrics"
         v-if="!minimized && mobile && view === 'lyrics'"
       >
-        <lyrics
+        <lyrics-viewer
           class="lyrics__text"
           v-if="track.lyrics"
-          :lyricObject="track.lyrics"
-          :isCurrentTrack="true"
-        ></lyrics>
+          :model="track.lyrics"
+          :current="true"
+        ></lyrics-viewer>
       </div>
       <div
         class="audio-player__up-next"
@@ -257,7 +257,7 @@ import { Component, Vue, Watch } from 'vue-property-decorator';
 import { Howl } from 'howler';
 import * as moment from 'moment';
 import QueueList from '@/components/audio-player/QueueList.vue';
-import Lyrics from '@/components/Lyrics.vue';
+import LyricsViewer from '@/components/LyricsViewer.vue';
 import {
   PlayerState, QueuedTrack, TrackQueue, RepeatType,
 } from '@/store/modules/player';
@@ -271,7 +271,7 @@ type View = 'none' | 'lyrics' | 'cast' | 'queue';
 
 @Component({
   components: {
-    Lyrics,
+    LyricsViewer,
     QueueList,
   },
 })

--- a/web/src/components/edit/EditTrackDialog.vue
+++ b/web/src/components/edit/EditTrackDialog.vue
@@ -93,7 +93,6 @@
         <timestamped-editor
           v-model="form.lyrics"
           :track="track"
-          :timestamped.sync="timestamps"
         ></timestamped-editor>
       </v-card-text>
       <v-card-actions></v-card-actions>
@@ -129,18 +128,16 @@ export default class EditTrackDialog extends Vue {
   @Prop({ type: Object }) private album;
   private dialog = false;
   private form: Form = { ...defaults };
-  private timestamps = true;
   private loading = false;
+
   get includes() {
     return 'reciter,lyrics,album.tracks,media';
   }
+
   @Watch('dialog')
   onDialogStateChanged(opened) {
     if (opened) {
       this.resetForm();
-      if (this.lyrics.format === Format.JSON_V1) {
-        this.timestamps = this.lyrics.meta.timestamps;
-      }
     }
   }
 
@@ -183,7 +180,7 @@ export default class EditTrackDialog extends Vue {
       this.form = {
         ...this.form,
         title,
-        lyrics: this.lyrics.data,
+        lyrics: this.lyrics,
       };
     }
   }
@@ -272,10 +269,6 @@ export default class EditTrackDialog extends Vue {
   }
   prepareLyrics() {
     const lyrics = clone(this.lyrics);
-
-    if (!this.timestamps) {
-      lyrics.meta.timestamps = false;
-    }
 
     return JSON.stringify(lyrics);
   }

--- a/web/src/components/edit/EditTrackDialog.vue
+++ b/web/src/components/edit/EditTrackDialog.vue
@@ -101,11 +101,12 @@ import {
 import { clone } from '@/utils/clone';
 import * as Format from '@/constants/lyrics/format';
 import TimestampedEditor from '@/components/edit/lyrics/TimestampedEditor.vue';
+import { Lyrics } from '@/types/lyrics';
 
 interface Form {
-  title: string | null;
-  lyrics: Array<any> | null;
-  audio: string | Blob | null;
+  title: string|null;
+  lyrics: Lyrics|null;
+  audio: string|Blob|null;
 }
 const defaults: Form = {
   title: null,
@@ -134,7 +135,7 @@ export default class EditTrackDialog extends Vue {
     }
   }
 
-  get lyrics() {
+  get lyrics(): Lyrics|null {
     if (!this.track.lyrics) {
       return null;
     }
@@ -144,7 +145,7 @@ export default class EditTrackDialog extends Vue {
       return JSON.parse(content);
     }
 
-    return content.split(/\n/gi).map((text) => {
+    const data = content.split(/\n/gi).map((text) => {
       if (text.trim().length === 0) {
         return null;
       }
@@ -154,6 +155,13 @@ export default class EditTrackDialog extends Vue {
         lines: [{ text: text.trim(), repeat: 0 }],
       };
     }).filter((val) => val !== null);
+
+    return {
+      meta: {
+        timestamps: false,
+      },
+      data,
+    };
   }
 
   addFile(e) {

--- a/web/src/components/edit/EditTrackDialog.vue
+++ b/web/src/components/edit/EditTrackDialog.vue
@@ -83,13 +83,6 @@
             </template>
           </v-file-input>
         </div>
-        <v-textarea
-          v-if="false"
-          outlined
-          label="Lyrics"
-          v-model="form.lyrics.data"
-          required
-        ></v-textarea>
         <timestamped-editor
           v-model="form.lyrics"
           :track="track"

--- a/web/src/components/edit/EditTrackDialog.vue
+++ b/web/src/components/edit/EditTrackDialog.vue
@@ -268,7 +268,7 @@ export default class EditTrackDialog extends Vue {
     this.loading = false;
   }
   prepareLyrics() {
-    const lyrics = clone(this.lyrics);
+    const lyrics = clone(this.form.lyrics);
 
     return JSON.stringify(lyrics);
   }

--- a/web/src/components/edit/lyrics/TimestampedEditor.vue
+++ b/web/src/components/edit/lyrics/TimestampedEditor.vue
@@ -410,7 +410,7 @@ export default class TimestampedEditor extends Vue {
 
   getNextLineCoordinates(current: LineCoordinates): LineCoordinates {
     const next = { ...current };
-    const group = this.lyrics[current.group];
+    const group = this.lyrics.data[current.group];
     if (group.lines.length > current.line + 1) {
       next.line = current.line + 1;
     } else if (this.lyrics.data.length > current.group + 1) {

--- a/web/src/components/edit/lyrics/TimestampedEditor.vue
+++ b/web/src/components/edit/lyrics/TimestampedEditor.vue
@@ -177,7 +177,7 @@ export default class TimestampedEditor extends Vue {
     if (this.$store.state.player.current) {
       timestamp = this.$store.state.player.seek;
     } else if (this.lyrics.data.length > at + 1) {
-      timestamp = this.lyrics[at].timestamp;
+      timestamp = this.lyrics.data[at].timestamp;
     } else {
       timestamp = 0;
     }
@@ -428,7 +428,7 @@ export default class TimestampedEditor extends Vue {
       previous.line = current.line - 1;
     } else if (current.group !== 0) {
       previous.group = current.group - 1;
-      previous.line = this.lyrics[previous.group].lines.length - 1;
+      previous.line = this.lyrics.data[previous.group].lines.length - 1;
     }
 
     return previous;
@@ -497,7 +497,7 @@ export default class TimestampedEditor extends Vue {
   }
 
   getGroup(coordinates: LineCoordinates): LineGroup|null {
-    return this.lyrics[coordinates.group];
+    return this.lyrics.data[coordinates.group];
   }
 
   /**

--- a/web/src/components/edit/lyrics/TimestampedEditor.vue
+++ b/web/src/components/edit/lyrics/TimestampedEditor.vue
@@ -6,10 +6,14 @@
       <div class="header__actions">
         <v-tooltip :attach="true" top>
           <template v-slot:activator="{ on }">
-            <v-btn v-on="on" icon @click="toggleTimestamps" v-if="timestamps"><v-icon>timer_off</v-icon></v-btn>
-            <v-btn v-on="on" icon @click="toggleTimestamps" v-else><v-icon>timer</v-icon></v-btn>
+            <v-btn v-on="on" icon @click="toggleTimestamps" v-if="lyrics.meta.timestamps">
+              <v-icon>timer_off</v-icon>
+            </v-btn>
+            <v-btn v-on="on" icon @click="toggleTimestamps" v-else>
+              <v-icon>timer</v-icon>
+            </v-btn>
           </template>
-          <span v-if="timestamps">Disable timestamps</span>
+          <span v-if="lyrics.meta.timestamps">Disable timestamps</span>
           <span v-else>Enable timestamps</span>
         </v-tooltip>
         <template>
@@ -27,10 +31,10 @@
     <div class="editor__content">
       <div
           :class="{ group: true, 'group--highlighted': playingGroup === groupId }"
-          v-for="(group, groupId) in lyrics"
+          v-for="(group, groupId) in lyrics.data"
           :key="groupId"
       >
-        <div class="group__timestamp" v-if="timestamps">
+        <div class="group__timestamp" v-if="lyrics.meta.timestamps">
           <timestamp v-model="group.timestamp" @change="change" />
         </div>
         <div class="group__lines">
@@ -59,14 +63,14 @@
 
 <script lang="ts">
 import {
-  Component, Model, Prop, PropSync, Vue, Watch,
+  Component, Model, Prop, Vue, Watch,
 } from 'vue-property-decorator';
 import { position } from 'caret-pos';
 import RepeatLine from '@/components/edit/lyrics/RepeatLine.vue';
 import EditableText from '@/components/edit/lyrics/EditableText.vue';
 import Timestamp from '@/components/edit/lyrics/Timestamp.vue';
 import StateHistory from '@/utils/StateHistory';
-import { LyricsData, Line, LineGroup } from '@/types/lyrics';
+import { Line, LineGroup, Lyrics } from '@/types/lyrics';
 import { clone } from '@/utils/clone';
 import LyricsHighlighter from '@/utils/LyricsHighlighter';
 
@@ -74,6 +78,13 @@ interface LineCoordinates {
   group: number;
   line: number;
 }
+
+const defaultLyrics = () => ({
+  meta: {
+    timestamps: true,
+  },
+  data: [],
+});
 
 @Component({
   components: {
@@ -83,14 +94,13 @@ interface LineCoordinates {
   },
 })
 export default class TimestampedEditor extends Vue {
-  @Model('change', { type: Array }) readonly model!: LyricsData;
-  @PropSync('timestamped', { type: Boolean, default: true }) timestamps!: boolean;
+  @Model('change', { type: Object }) readonly model!: Lyrics;
   @Prop({ type: Object }) readonly track!: any;
 
-  private lyrics: LyricsData = [];
+  private lyrics: Lyrics = defaultLyrics();
   private focused = false;
   private selected: LineCoordinates|null = null;
-  private history: StateHistory<LyricsData> = new StateHistory([]);
+  private history: StateHistory<Lyrics> = new StateHistory(defaultLyrics());
   private highlighter: LyricsHighlighter|null = null;
   private changeTimeout: number|undefined;
 
@@ -99,7 +109,7 @@ export default class TimestampedEditor extends Vue {
       editor: true,
       'editor--dark': this.$vuetify.theme.dark,
       'editor--focused': this.focused,
-      'editor--timestamped': this.timestamps,
+      'editor--timestamped': this.lyrics.meta.timestamps,
     };
   }
 
@@ -132,11 +142,12 @@ export default class TimestampedEditor extends Vue {
   mounted() {
     this.lyrics = clone(this.model);
     this.history = new StateHistory(this.lyrics);
-    this.highlighter = new LyricsHighlighter(this.$store.state.player, this.model);
+    this.highlighter = new LyricsHighlighter(this.$store.state.player, this.model.data);
   }
 
   toggleTimestamps() {
-    this.timestamps = !this.timestamps;
+    this.lyrics.meta.timestamps = !this.lyrics.meta.timestamps;
+    this.change();
   }
 
   @Watch('model')
@@ -165,12 +176,12 @@ export default class TimestampedEditor extends Vue {
     let timestamp: number|null = 0;
     if (this.$store.state.player.current) {
       timestamp = this.$store.state.player.seek;
-    } else if (this.lyrics.length > at + 1) {
+    } else if (this.lyrics.data.length > at + 1) {
       timestamp = this.lyrics[at].timestamp;
     } else {
       timestamp = 0;
     }
-    this.lyrics.splice(at + 1, 0, {
+    this.lyrics.data.splice(at + 1, 0, {
       timestamp,
       lines: lines || [
         { text: '', repeat: 0 },
@@ -253,7 +264,7 @@ export default class TimestampedEditor extends Vue {
       this.addNewGroup(coordinates.group, linesToMove);
 
       if (group.lines.length === 0) {
-        this.lyrics.splice(coordinates.group, 1);
+        this.lyrics.data.splice(coordinates.group, 1);
         this.change();
         // TODO - solve this when updating component to use change events properly.
       }
@@ -305,7 +316,7 @@ export default class TimestampedEditor extends Vue {
     }
 
     // If this is the last group and the last line, don't delete it.
-    if (this.lyrics.length === 1 && group.lines.length === 1) {
+    if (this.lyrics.data.length === 1 && group.lines.length === 1) {
       return;
     }
 
@@ -363,7 +374,7 @@ export default class TimestampedEditor extends Vue {
   }
 
   deleteGroup({ group }: LineCoordinates) {
-    this.lyrics.splice(group, 1);
+    this.lyrics.data.splice(group, 1);
     this.change();
   }
 
@@ -402,7 +413,7 @@ export default class TimestampedEditor extends Vue {
     const group = this.lyrics[current.group];
     if (group.lines.length > current.line + 1) {
       next.line = current.line + 1;
-    } else if (this.lyrics.length > current.group + 1) {
+    } else if (this.lyrics.data.length > current.group + 1) {
       next.group = current.group + 1;
       next.line = 0;
     }

--- a/web/src/types/lyrics.ts
+++ b/web/src/types/lyrics.ts
@@ -18,3 +18,9 @@ export interface Lyrics {
   meta: LyricsMetadata;
   data: LyricsData;
 }
+
+export interface LyricsModel {
+  id: string;
+  content: string;
+  format: 1|2;
+}

--- a/web/src/views/public/tracks/TrackView.vue
+++ b/web/src/views/public/tracks/TrackView.vue
@@ -94,11 +94,11 @@
             </v-card-title>
             <v-card-text class="lyrics__content" :class="{ 'black--text': !isDark }">
               <template v-if="track">
-                <lyrics
+                <lyrics-viewer
                   v-if="track.lyrics"
-                  :lyricObject="track.lyrics"
-                  :isCurrentTrack="isSameTrackPlaying"
-                ></lyrics>
+                  :model="track.lyrics"
+                  :current="isSameTrackPlaying"
+                ></lyrics-viewer>
                 <div class="lyrics__empty" v-else>
                   <div
                     class="lyrics__empty-message"
@@ -163,19 +163,19 @@ import {
 } from 'vue-property-decorator';
 import Vibrant from 'node-vibrant';
 import ReciterHeroSkeleton from '@/components/loaders/ReciterHeroSkeleton.vue';
-import Lyrics from '@/components/Lyrics.vue';
 import LyricsSkeleton from '@/components/loaders/LyricsSkeleton.vue';
 import MoreTracksSkeleton from '@/components/loaders/MoreTracksSkeleton.vue';
 import EditTrackDialog from '@/components/edit/EditTrackDialog.vue';
 import { getTracks, getTrack } from '@/services/tracks';
+import LyricsViewer from '@/components/LyricsViewer.vue';
 
 @Component({
   components: {
+    LyricsViewer,
     ReciterHeroSkeleton,
     LyricsSkeleton,
     MoreTracksSkeleton,
     EditTrackDialog,
-    Lyrics,
   },
 })
 export default class TrackPage extends Vue {


### PR DESCRIPTION
Added a bit of refactoring.

- [x] Make the `Lyrics` component that renders lyrics on the track page respect the `.meta.timestamps` field and show/hide timestamps based on that.
- [x] Make the `TimestampedEditor` take the whole `Lyrics` object, including the meta field. This keeps toggling the timestamp visibility in the state history as well, and simplifies the logic of the `EditTrackDialog`.
- [x] Fix saving the track in `EditTrackDialog`
- [x] Make existing plain text lyrics work with the updated `JSON_V1` format.