### PR TITLE
Don't show lyrics if not plain text

### DIFF
--- a/web/src/views/public/tracks/Show.vue
+++ b/web/src/views/public/tracks/Show.vue
@@ -96,13 +96,16 @@
             </v-card-title>
             <v-card-text class="lyrics__content" :class="{ 'black--text': !isDark }">
               <template v-if="track">
-                <div v-if="track.lyrics">
+                <div v-if="track.lyrics && track.lyrics.format === 1">
                   <div v-html="prepareLyrics(track.lyrics.content)"></div>
                 </div>
                 <div class="lyrics__empty" v-else>
                   <div class="lyrics__empty-message"
                        :class="{ 'lyrics__empty-message--dark': isDark }"
-                  >We don't have a write-up for this nawha yet.</div>
+                  >
+                    <span v-if="track.lyrics">An update is required to view this write-up.</span>
+                    <span v-else>We don't have a write-up for this nawha yet.</span>
+                  </div>
                 </div>
               </template>
               <div v-else>


### PR DESCRIPTION
In preparation for the Timestamped Lyrics release, we want to prevent displaying the JSON formatted lyrics in the app until the app has updated to support the new format.

This is especially necessary because, while the frontend is cached in the browser, the API response will not be. 

If the user has a cached version of the app and we deploy the timestamped lyrics feature, this will be shown:

![image](https://user-images.githubusercontent.com/379169/78417914-21ab2600-7605-11ea-94fa-fc2c865a904a.png)

Instead, with this change, the user will now see 
![image](https://user-images.githubusercontent.com/379169/78417922-34255f80-7605-11ea-8867-14e37d9871a9.png)

**We need to get this PR out to production ASAP so that there's less chance a user will be on a far too outdated version of the app.**