### PR TITLE
Use a more sane max width for the application.

### DIFF
--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -71,17 +71,10 @@ export default class App extends Vue {
 @import url('https://fonts.googleapis.com/css?family=Bellefair|Roboto+Condensed:300,300i,400,400i,700,700i|Roboto+Slab:100,300,400,700|Material+Icons|Material+Icons+Outlined');
 @import url('https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css');
 
-body.scroll--none {
-  overflow: hidden;
-  overscroll-behavior: contain;
-}
-// Layout Styles
-.page-section {
-  padding: 24px 48px;
-}
-
 .app__section {
   padding-bottom: 24px !important;
+  max-width: 1000px;
+
   .section__title {
     font-size: 1.4rem; // Overriding the font size.
     font-weight: map-deep-get($headings, 'h5', 'weight');
@@ -98,9 +91,6 @@ body.scroll--none {
 }
 
 .app--xs, .app--sm {
-  .page-section {
-    padding: 24px;
-  }
   .app__section {
     padding: 24px;
   }

--- a/web/src/components/auth/UserMenu.vue
+++ b/web/src/components/auth/UserMenu.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <v-menu :close-on-content-click="false" v-model="open">
+    <v-menu :close-on-content-click="false" v-model="open" left>
       <template v-slot:activator="{ on }">
         <v-btn icon class="user-menu" v-on="on">
           <v-icon>person</v-icon>

--- a/web/src/layouts/Public.vue
+++ b/web/src/layouts/Public.vue
@@ -20,26 +20,28 @@
       </v-list>
     </v-navigation-drawer>
     <v-app-bar class="app-bar" :color="(!isDark) ? 'white' : null" app fixed elevate-on-scroll>
-      <div class="app-bar__left">
-        <nav class="nav__buttons" v-if="$vuetify.breakpoint.lgAndUp">
-          <v-btn text v-for="(link) in navigation" class="nav__btn" :key="link.to" :to="link.to">
-            {{ link.title }}
-          </v-btn>
-        </nav>
-        <v-app-bar-nav-icon @click.native="drawer = !drawer" v-else />
-      </div>
-      <div class="app-bar__center">
-        <v-toolbar-title class="nav__title">
-          <router-link to="/" tag="div" class="masthead__logo">
-            <logo-icon class="masthead__logo__icon" />
-            <logo-wordmark :class="{ 'masthead__logo__wordmark': true, 'masthead__logo__wordmark--dark': isDark }" />
-          </router-link>
-        </v-toolbar-title>
-      </div>
-      <div class="app-bar__right nav__search">
-        <search />
-        <user-menu class="user-menu" />
-      </div>
+      <v-container class="app-bar__container">
+        <div class="app-bar__left">
+          <nav class="nav__buttons" v-if="$vuetify.breakpoint.lgAndUp">
+            <v-btn text v-for="(link) in navigation" class="nav__btn" :key="link.to" :to="link.to">
+              {{ link.title }}
+            </v-btn>
+          </nav>
+          <v-app-bar-nav-icon @click.native="drawer = !drawer" v-else />
+        </div>
+        <div class="app-bar__center">
+          <v-toolbar-title class="nav__title">
+            <router-link to="/" tag="div" class="masthead__logo">
+              <logo-icon class="masthead__logo__icon" />
+              <logo-wordmark :class="{ 'masthead__logo__wordmark': true, 'masthead__logo__wordmark--dark': isDark }" />
+            </router-link>
+          </v-toolbar-title>
+        </div>
+        <div class="app-bar__right nav__search">
+          <search />
+          <user-menu class="user-menu" />
+        </div>
+      </v-container>
     </v-app-bar>
     <v-content>
       <v-container fluid :class="{ 'grey lighten-5': !isDark }" class="main-container">
@@ -142,6 +144,14 @@ export default class PublicVuetify extends Vue {
   margin: auto;
 }
 
+.app-bar__container {
+  display: flex;
+  align-items: center;
+  padding: 4px 0;
+  margin: 0 auto;
+  position: relative;
+  height: 64px;
+}
 .app-bar__left, .app-bar__right {
   flex: 1;
   display: flex;

--- a/web/src/layouts/Public.vue
+++ b/web/src/layouts/Public.vue
@@ -22,20 +22,22 @@
     <v-app-bar class="app-bar" :color="(!isDark) ? 'white' : null" app fixed elevate-on-scroll>
       <v-container class="app-bar__container">
         <div class="app-bar__left">
-          <nav class="nav__buttons" v-if="$vuetify.breakpoint.lgAndUp">
-            <v-btn text v-for="(link) in navigation" class="nav__btn" :key="link.to" :to="link.to">
-              {{ link.title }}
-            </v-btn>
-          </nav>
-          <v-app-bar-nav-icon @click.native="drawer = !drawer" v-else />
-        </div>
-        <div class="app-bar__center">
+          <v-app-bar-nav-icon @click.native="drawer = !drawer" v-if="$vuetify.breakpoint.mdAndDown" />
+
           <v-toolbar-title class="nav__title">
             <router-link to="/" tag="div" class="masthead__logo">
               <logo-icon class="masthead__logo__icon" />
               <logo-wordmark :class="{ 'masthead__logo__wordmark': true, 'masthead__logo__wordmark--dark': isDark }" />
             </router-link>
           </v-toolbar-title>
+
+          <nav class="nav__buttons" v-if="$vuetify.breakpoint.lgAndUp">
+            <v-btn text v-for="(link) in navigation" class="nav__btn" :key="link.to" :to="link.to">
+              {{ link.title }}
+            </v-btn>
+          </nav>
+        </div>
+        <div class="app-bar__center">
         </div>
         <div class="app-bar__right nav__search">
           <search />
@@ -141,7 +143,7 @@ export default class PublicVuetify extends Vue {
   font-weight: 400;
 }
 .nav__title {
-  margin: auto;
+  margin-right: 12px;
 }
 
 .app-bar__container {

--- a/web/src/styles/variables.scss
+++ b/web/src/styles/variables.scss
@@ -1,0 +1,4 @@
+$container-max-widths: (
+  'lg': 1200px,
+  'xl': 1200px
+);


### PR DESCRIPTION
Almost every single other website uses a max width of around 1100-1200px for their application. This ensures that the app looks decent even when some people ( 😉) choose to use the website in full screen on a 4k screen.

Here are some comparison screenshots.

### Before
![Screen Shot 2020-04-05 at 10 58 42 PM](https://user-images.githubusercontent.com/379169/78519337-0c630280-7791-11ea-9d68-1c2d28d61c85.png)

### After

![Screen Shot 2020-04-05 at 11 00 25 PM](https://user-images.githubusercontent.com/379169/78519432-51873480-7791-11ea-8af9-f5d741a658ca.png)

---

A more useful comparison might be on a normal, yet still really wide, resolution:

### Before
![Screen Shot 2020-04-05 at 11 02 25 PM](https://user-images.githubusercontent.com/379169/78519501-98752a00-7791-11ea-9660-4be827c43c0d.png)

### After
![Screen Shot 2020-04-05 at 11 02 46 PM](https://user-images.githubusercontent.com/379169/78519508-a034ce80-7791-11ea-8de7-3e4d18a96dfd.png)


---

## Comparable Sites
<img width="2663" alt="Screen Shot 2020-04-05 at 11 07 05 PM" src="https://user-images.githubusercontent.com/379169/78519712-38cb4e80-7792-11ea-8fbd-199696e282a4.png">
<img width="2663" alt="Screen Shot 2020-04-05 at 11 05 55 PM" src="https://user-images.githubusercontent.com/379169/78519730-408af300-7792-11ea-9514-b30f90436aa9.png">

![image](https://user-images.githubusercontent.com/379169/78519809-6912ed00-7792-11ea-9334-367597b9705f.png)

<img width="2663" alt="Screen Shot 2020-04-05 at 11 11 05 PM" src="https://user-images.githubusercontent.com/379169/78519922-c0b15880-7792-11ea-95ee-6bae2d35752c.png">

