### PR TITLE
Add db:sync and db:refresh commands to dev tool.

### DIFF
--- a/dev
+++ b/dev
@@ -36,11 +36,16 @@ if [ $# -gt 0 ];then
       run api \
         ./vendor/bin/phpunit "$@"
 
-    # If "db" is used, run mysql
-    elif [ "$1" == "db" ] || [ "$1" == "mysql" ]; then
-      shift 1
-      run db \
-        mysql -u docker -d nawhas "$@"
+    elif [ "$1" == "db:sync" ]; then
+      $COMPOSE up -d --force-recreate db
+      run api php artisan doctrine:migrations:migrate
+      run db sync_database
+
+    elif [ "$1" == "db:refresh" ]; then
+      $COMPOSE up -d --force-recreate db
+      run db clean_database
+      run api php artisan doctrine:migrations:migrate
+      run db sync_database
 
     # Else, pass-thru args to docker-compose
     else

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,7 @@ services:
       - ./docker/postgres/.env
     volumes:
       - postgres:/var/lib/postgresql/data
-      - ./docker/postgres/sync.sh:/usr/bin/syncdb
+      - ./docker/postgres/scripts:/usr/local/sbin
     networks:
       - nawhas
   cache:

--- a/docker/postgres/scripts/clean_database
+++ b/docker/postgres/scripts/clean_database
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+psql -U "$POSTGRES_USER" -d postgres -c "SELECT pg_terminate_backend(pg_stat_activity.pid) FROM pg_stat_activity WHERE pg_stat_activity.datname = '$POSTGRES_DB' AND pid <> pg_backend_pid();" > /dev/null
+psql -U "$POSTGRES_USER" -d postgres -c "DROP DATABASE $POSTGRES_DB;" > /dev/null
+psql -U "$POSTGRES_USER" -d postgres -c "CREATE DATABASE $POSTGRES_DB;" > /dev/null

--- a/docker/postgres/scripts/sync_database
+++ b/docker/postgres/scripts/sync_database
@@ -13,7 +13,6 @@ pg_dump \
   --no-acl \
   --no-owner \
   --schema=public \
-  --table _doctrine \
   --table reciters \
   --table albums \
   --table tracks \
@@ -22,14 +21,11 @@ pg_dump \
   --table track_media \
   --table reciter_visits \
   --table track_visits \
-  --table users \
   -f "$DUMP" \
   -Fc \
   "$STG_DB_CONNECTION";
 
-psql -U "$POSTGRES_USER" -d postgres -c "SELECT pg_terminate_backend(pg_stat_activity.pid) FROM pg_stat_activity WHERE pg_stat_activity.datname = '$POSTGRES_DB' AND pid <> pg_backend_pid();" > /dev/null
-psql -U "$POSTGRES_USER" -d postgres -c "DROP DATABASE $POSTGRES_DB;" > /dev/null
-psql -U "$POSTGRES_USER" -d postgres -c "CREATE DATABASE $POSTGRES_DB;" > /dev/null
+echo "Restoring database from $DUMP.";
 
 PGPASSWORD="$POSTGRES_PASSWORD" pg_restore \
   --no-privileges \
@@ -37,6 +33,7 @@ PGPASSWORD="$POSTGRES_PASSWORD" pg_restore \
   --if-exists \
   --no-acl \
   --no-owner \
+  --disable-triggers \
   -U "$POSTGRES_USER" \
   --schema=public \
   -d "$POSTGRES_DB" \


### PR DESCRIPTION
`./dev db:sync` will synchronize your database with the data from the staging db without destroying your **users**.

`./dev db:refresh` will set everything back up exactly as staging has it (without certain tables, like `users` or `social_accounts`

```bash
$ dev db:sync
Recreating nawhas_db ... done
+ docker-compose exec api php artisan doctrine:migrations:migrate
Nothing to migrate.
+ run db sync_database
+ set -x
+ docker-compose exec db sync_database
Dumping database from staging to /opt/dump.sql.
Restoring database from /opt/dump.sql.
Done!
```