### PR TITLE
Better handle lyrics modifications.

### DIFF
--- a/api/app/Entities/Track.php
+++ b/api/app/Entities/Track.php
@@ -13,8 +13,6 @@ use App\Enum\MediaProvider;
 use App\Enum\MediaType;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use Doctrine\Common\Collections\Criteria;
-use Doctrine\Common\Collections\Selectable;
 use Illuminate\Support\Str;
 use Ramsey\Uuid\{Uuid, UuidInterface};
 use Zain\LaravelDoctrine\Jetpack\Serializer\SerializesAttributes;
@@ -92,6 +90,11 @@ class Track implements Entity, TimestampedEntity, Visitable, AuditableEntity
     public function replaceLyrics(Lyrics $lyrics): void
     {
         $this->lyrics = $lyrics;
+    }
+
+    public function removeLyrics(): void
+    {
+        $this->lyrics = null;
     }
 
     /**

--- a/api/app/Http/Controllers/Api/TracksController.php
+++ b/api/app/Http/Controllers/Api/TracksController.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\Api;
 
-use App\Database\Doctrine\EntityManager;
 use App\Entities\Album;
 use App\Entities\Lyrics;
 use App\Entities\Reciter;
@@ -13,10 +12,12 @@ use App\Entities\Media;
 use App\Http\Controllers\Controller;
 use App\Http\Transformers\TrackTransformer;
 use App\Modules\Library\Events\LyricsCreated;
+use App\Modules\Library\Events\LyricsDeleted;
 use App\Modules\Library\Events\LyricsModified;
 use App\Modules\Library\Events\TrackCreated;
 use App\Modules\Library\Events\TrackDeleted;
 use App\Modules\Library\Events\TrackModified;
+use App\Modules\Lyrics\Documents\Factory as DocumentFactory;
 use App\Modules\Lyrics\Documents\Format;
 use App\Repositories\TrackRepository;
 use App\Visits\Manager as VisitsManager;
@@ -25,6 +26,7 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Validation\ValidationException;
+use JsonException;
 
 class TracksController extends Controller
 {
@@ -77,17 +79,7 @@ class TracksController extends Controller
             $track->setTitle($request->get('title'));
         }
         if ($request->has('lyrics')) {
-            $old = $track->getLyrics();
-
-            $format = $request->get('format', Format::PLAIN_TEXT);
-            $lyrics = new Lyrics($track, $request->get('lyrics'), new Format($format));
-            $track->replaceLyrics($lyrics);
-
-            if ($old === null) {
-                event(new LyricsCreated($lyrics));
-            } else {
-                event(new LyricsModified($lyrics, $old));
-            }
+            $this->updateLyrics($track, $request->get('lyrics'), (int)$request->get('format', Format::PLAIN_TEXT));
         }
 
         event(new TrackModified($track));
@@ -133,5 +125,42 @@ class TracksController extends Controller
         $this->repository->persist($track);
 
         return $this->respondWithItem($track);
+    }
+
+    private function updateLyrics(Track $track, ?string $content, int $format): void
+    {
+        if ($content === null) {
+            return;
+        }
+
+        $old = $track->getLyrics();
+
+        try {
+            $document = DocumentFactory::create($content, new Format($format));
+        } catch (JsonException  $e) {
+            throw ValidationException::withMessages(['lyrics' => 'The lyrics content is invalid.']);
+        }
+
+        // If there's no old version of lyrics, and the new document is empty, ignore this change.
+        if ($old === null && $document->isEmpty()) {
+            return;
+        }
+
+        // If an old version exists, and the new version is empty, we need to delete the old version.
+        if ($document->isEmpty()) {
+            $track->removeLyrics();
+            event(new LyricsDeleted($old));
+            return;
+        }
+
+        // Otherwise, add new lyrics.
+        $lyrics = new Lyrics($track, $content, new Format($format));
+        $track->replaceLyrics($lyrics);
+
+        if ($old === null) {
+            event(new LyricsCreated($lyrics));
+        } else {
+            event(new LyricsModified($lyrics, $old));
+        }
     }
 }

--- a/api/app/Modules/Library/Events/LyricsDeleted.php
+++ b/api/app/Modules/Library/Events/LyricsDeleted.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Modules\Library\Events;
+
+use App\Entities\Contracts\Events\EntityPersisted;
+use App\Entities\Lyrics;
+use App\Enum\ChangeType;
+use App\Modules\Audit\Events\AuditableEvent;
+
+class LyricsDeleted implements EntityPersisted, AuditableEvent
+{
+    public Lyrics $lyrics;
+
+    public function __construct(Lyrics $lyrics)
+    {
+        $this->lyrics = $lyrics;
+    }
+
+    public function getEntity(): Lyrics
+    {
+        return $this->lyrics;
+    }
+
+    public function getEntityType(): string
+    {
+        return Lyrics::class;
+    }
+
+    public function getChangeType(): ChangeType
+    {
+        return ChangeType::DELETED();
+    }
+}

--- a/api/app/Modules/Lyrics/Documents/Document.php
+++ b/api/app/Modules/Lyrics/Documents/Document.php
@@ -8,5 +8,6 @@ interface Document
 {
     public function getFormat(): Format;
     public function render(): string;
+    public function isEmpty(): bool;
     public function __toString();
 }

--- a/api/app/Modules/Lyrics/Documents/JsonV1/Document.php
+++ b/api/app/Modules/Lyrics/Documents/JsonV1/Document.php
@@ -8,6 +8,7 @@ use App\Modules\Lyrics\Documents\Document as DocumentContract;
 use App\Modules\Lyrics\Documents\Format;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Stringable;
 
 class Document implements DocumentContract, Jsonable
 {
@@ -86,5 +87,12 @@ class Document implements DocumentContract, Jsonable
     public function __toString()
     {
         return $this->render();
+    }
+
+    public function isEmpty(): bool
+    {
+        return (new Stringable($this->render()))
+            ->trim()
+            ->isEmpty();
     }
 }

--- a/api/app/Modules/Lyrics/Documents/PlainText/Document.php
+++ b/api/app/Modules/Lyrics/Documents/PlainText/Document.php
@@ -6,6 +6,7 @@ namespace App\Modules\Lyrics\Documents\PlainText;
 
 use App\Modules\Lyrics\Documents\Document as DocumentContract;
 use App\Modules\Lyrics\Documents\Format;
+use Illuminate\Support\Stringable;
 
 class Document implements DocumentContract
 {
@@ -29,6 +30,13 @@ class Document implements DocumentContract
         $content = trim($content);
 
         return $content;
+    }
+
+    public function isEmpty(): bool
+    {
+        return (new Stringable($this->render()))
+            ->trim()
+            ->isEmpty();
     }
 
     public function __toString()

--- a/api/tests/Unit/Modules/Lyrics/Documents/JsonV1DocumentTest.php
+++ b/api/tests/Unit/Modules/Lyrics/Documents/JsonV1DocumentTest.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace Tests\Unit\Modules\Lyrics\Documents;
 
 use App\Modules\Lyrics\Documents\JsonV1\Document;
-use Illuminate\Validation\ValidationException;
-use JsonException;
 use Tests\TestCase;
 
 class JsonV1DocumentTest extends TestCase
@@ -125,7 +123,6 @@ class JsonV1DocumentTest extends TestCase
      */
     public function it_renders_to_string_properly(): void
     {
-
         $source = /** @lang JSON */ <<<JSON
         {
            "meta": {
@@ -169,5 +166,146 @@ class JsonV1DocumentTest extends TestCase
         $doc = Document::fromJson($source);
 
         $this->assertEquals($expected, $doc->render());
+    }
+
+    /**
+     * @test
+     * @dataProvider provideContentsForEmptyTest
+     */
+    public function it_determines_empty_documents_correctly(string $content, bool $expected): void
+    {
+
+        $doc = Document::fromJson($content);
+
+        $this->assertEquals($expected, $doc->isEmpty());
+    }
+
+    public function provideContentsForEmptyTest(): array
+    {
+        return [
+            'empty json' => ['{}', true],
+            'empty document with timestamps enabled' => [
+                /** @lang JSON */ <<<JSON
+                {
+                  "meta": {
+                    "timestamps": true
+                  },
+                  "data": [
+                    {
+                      "timestamp": 0,
+                      "lines": [
+                        {
+                          "text": "",
+                          "repeat": 0
+                        }
+                      ]
+                    }
+                  ]
+                }
+                JSON,
+                true,
+            ],
+            'empty document with timestamps disabled' => [
+                /** @lang JSON */ <<<JSON
+                {
+                  "meta": {
+                    "timestamps": false
+                  },
+                  "data": [
+                    {
+                      "timestamp": 0,
+                      "lines": [
+                        {
+                          "text": "",
+                          "repeat": 0
+                        }
+                      ]
+                    }
+                  ]
+                }
+                JSON,
+                true,
+            ],
+            'lots_of_empty_document_lines' => [
+                /** @lang JSON */ <<<JSON
+                {
+                  "meta": {
+                    "timestamps": false
+                  },
+                  "data": [
+                    {
+                      "timestamp": 0,
+                      "lines": [
+                        {
+                          "text": "",
+                          "repeat": 0
+                        },
+                        {
+                          "text": "",
+                          "repeat": 0
+                        },
+                        {
+                          "text": "\\t\\t\\t",
+                          "repeat": 0
+                        },
+                        {
+                          "text": "\\t",
+                          "repeat": 0
+                        }
+                      ]
+                    },
+                    {
+                      "timestamp": 0,
+                      "lines": [
+                        {
+                          "text": "    ",
+                          "repeat": 0
+                        },
+                        {
+                          "text": "     ",
+                          "repeat": 0
+                        }
+                      ]
+                    }
+                  ]
+                }
+                JSON,
+                true,
+            ],
+            'not empty' => [
+                /** @lang JSON */ <<<JSON
+                {
+                  "meta": {
+                    "timestamps": true
+                  },
+                  "data": [
+                    {
+                      "timestamp": 0,
+                      "lines": [
+                        {
+                          "text": "h",
+                          "repeat": 0
+                        }
+                      ]
+                    },
+                    {
+                      "timestamp": 0,
+                      "lines": [
+                        {
+                          "text": "    ",
+                          "repeat": 0
+                        },
+                        {
+                          "text": "     ",
+                          "repeat": 0
+                        }
+                      ]
+                    }
+                  ]
+                }
+                JSON,
+                false,
+            ],
+        ];
     }
 }

--- a/api/tests/Unit/Modules/Lyrics/Documents/PlainTextDocumentTest.php
+++ b/api/tests/Unit/Modules/Lyrics/Documents/PlainTextDocumentTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Modules\Lyrics\Documents;
+
+use App\Modules\Lyrics\Documents\PlainText\Document;
+use Tests\TestCase;
+
+class PlainTextDocumentTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider provideContentsForEmptyTest
+     */
+    public function it_determines_empty_documents_correctly(string $contents, bool $expected): void
+    {
+        $doc = new Document($contents);
+
+        $this->assertEquals($expected, $doc->isEmpty());
+    }
+
+    public function provideContentsForEmptyTest(): array
+    {
+        return [
+            'empty string' => ['', true],
+            'single line whitespace' => ['          ', true],
+            'multi-line whitespace' => [
+                <<<STR
+                
+                            
+                
+                STR,
+                true
+            ],
+            'not empty' => ['       . ', false],
+        ];
+    }
+}


### PR DESCRIPTION
When a track is updated with lyrics without any useful content, we will now smartly handle it.

If the content is empty and there's no old version of lyrics associated to the track, we'll ignore the change
entirely.

If the content is not empty and there is no old version of lyrics, this counts as a "create" operation.

If the content is empty and there is an old version of lyrics, this counts as a "delete" operation.

Tests included.

Fixes #205, fixes #206 

Example:
<img width="922" alt="image" src="https://user-images.githubusercontent.com/379169/87972882-8ab38e00-ca7c-11ea-9530-e1fb6cf3418e.png">
