### PR TITLE
Database Setup for Event Sourcing

### DIFF
--- a/api/app/Console/Commands/BootApplication.php
+++ b/api/app/Console/Commands/BootApplication.php
@@ -27,9 +27,7 @@ class BootApplication extends Command
                 'config:cache',
                 'route:cache',
                 'wait:database',
-                ['doctrine:migrations:migrate', [
-                    '--force' => true, '--allow-no-migration' => true,
-                ]],
+                'migrate:all',
                 'doctrine:clear:metadata:cache',
                 'doctrine:generate:proxies',
                 'search:settings:push',

--- a/api/app/Console/Commands/MigrateAllDatabases.php
+++ b/api/app/Console/Commands/MigrateAllDatabases.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+
+class MigrateAllDatabases extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'migrate:all';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Run database migrations for all connections.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle(): int
+    {
+        $this->warn('>> Running events migrations...');
+        $this->call('migrate', [
+            '--database' => 'events',
+            '--path' => 'database/migrations/events',
+            '--force' => true,
+        ]);
+
+        $this->warn('>> Running data migrations...');
+        $this->call('migrate', [
+            '--database' => 'data',
+            '--path' => 'database/migrations/data',
+            '--force' => true,
+        ]);
+
+        $this->warn('>> Running doctrine migrations...');
+        $this->call('doctrine:migrations:migrate', [
+            '--force' => true,
+            '--allow-no-migration' => true,
+        ]);
+        return 0;
+    }
+}

--- a/api/app/Events/StoredEvent.php
+++ b/api/app/Events/StoredEvent.php
@@ -8,14 +8,5 @@ use Spatie\EventSourcing\Models\EloquentStoredEvent;
 
 class StoredEvent extends EloquentStoredEvent
 {
-    public static function boot()
-    {
-        parent::boot();
-
-        static::creating(function (self $model) {
-            if (auth()->check()) {
-                $model->meta_data['user_id'] = auth()->user()->getAuthIdentifier();
-            }
-        });
-    }
+    protected $connection = 'events';
 }

--- a/api/config/database.php
+++ b/api/config/database.php
@@ -15,7 +15,7 @@ return [
     |
     */
 
-    'default' => env('DB_CONNECTION', 'data'),
+    'default' => env('DB_CONNECTION', 'pgsql'),
 
     /*
     |--------------------------------------------------------------------------

--- a/api/config/database.php
+++ b/api/config/database.php
@@ -15,7 +15,7 @@ return [
     |
     */
 
-    'default' => env('DB_CONNECTION', 'pgsql'),
+    'default' => env('DB_CONNECTION', 'data'),
 
     /*
     |--------------------------------------------------------------------------
@@ -71,6 +71,36 @@ return [
             'database' => env('DB_DATABASE', 'nawhas'),
             'username' => env('DB_USERNAME', 'docker'),
             'password' => env('DB_PASSWORD', 'secret'),
+            'charset' => 'utf8',
+            'prefix' => '',
+            'prefix_indexes' => true,
+            'schema' => 'public',
+            'sslmode' => 'prefer',
+        ],
+
+        'events' => [
+            'driver' => 'pgsql',
+            'url' => env('DATABASE_URL'),
+            'host' => env('EVENTS_DB_HOST', env('DB_HOST', 'nawhas_events_db')),
+            'port' => env('EVENTS_DB_PORT', env('DB_PORT', '5432')),
+            'database' => env('EVENTS_DB_DATABASE', env('DB_DATABASE', 'nawhas_events')),
+            'username' => env('EVENTS_DB_USERNAME', env('DB_USERNAME', 'docker')),
+            'password' => env('EVENTS_DB_PASSWORD', env('DB_PASSWORD', 'secret')),
+            'charset' => 'utf8',
+            'prefix' => '',
+            'prefix_indexes' => true,
+            'schema' => 'public',
+            'sslmode' => 'prefer',
+        ],
+
+        'data' => [
+            'driver' => 'pgsql',
+            'url' => env('DATABASE_URL'),
+            'host' => env('DATA_DB_HOST', env('DB_HOST', 'nawhas_data_db')),
+            'port' => env('DATA_DB_PORT', env('DB_PORT', '5432')),
+            'database' => env('DATA_DB_DATABASE', env('DB_DATABASE', 'nawhas_data')),
+            'username' => env('DATA_DB_USERNAME', env('DB_USERNAME', 'docker')),
+            'password' => env('DATA_DB_PASSWORD', env('DB_PASSWORD', 'secret')),
             'charset' => 'utf8',
             'prefix' => '',
             'prefix_indexes' => true,

--- a/api/config/doctrine.php
+++ b/api/config/doctrine.php
@@ -24,7 +24,7 @@ return [
         'default' => [
             'dev' => env('APP_DEBUG', false),
             'meta' => 'fluent',
-            'connection' => env('DB_CONNECTION', 'pgsql'),
+            'connection' => 'pgsql',
             'namespaces' => [],
             'paths' => [
                 base_path('app/Entities'),

--- a/api/config/event-sourcing.php
+++ b/api/config/event-sourcing.php
@@ -7,7 +7,7 @@ return [
      * will be registered to Projectionist automatically.
      */
     'auto_discover_projectors_and_reactors' => [
-        app()->path(),
+        app()->path('Modules'),
     ],
 
     /*
@@ -46,7 +46,7 @@ return [
      * To add extra behaviour you can change this to a class of your own. It should
      * extend the \Spatie\EventSourcing\Models\EloquentStoredEvent model.
      */
-    'stored_event_model' => \Spatie\EventSourcing\Models\EloquentStoredEvent::class,
+    'stored_event_model' => \App\Events\StoredEvent::class,
 
     /*
      * This class is responsible for storing events. To add extra behaviour you

--- a/api/database/migrations/events/2020_07_21_011640_create_snapshots_table.php
+++ b/api/database/migrations/events/2020_07_21_011640_create_snapshots_table.php
@@ -8,7 +8,7 @@ class CreateSnapshotsTable extends Migration
 {
     public function up(): void
     {
-        Schema::create('snapshots', function (Blueprint $table) {
+        Schema::connection('events')->create('snapshots', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->uuid('aggregate_uuid');
             $table->unsignedInteger('aggregate_version');
@@ -22,6 +22,6 @@ class CreateSnapshotsTable extends Migration
 
     public function down(): void
     {
-        Schema::drop('snapshots');
+        Schema::connection('events')->drop('snapshots');
     }
 }

--- a/api/database/migrations/events/2020_07_21_011640_create_stored_events_table.php
+++ b/api/database/migrations/events/2020_07_21_011640_create_stored_events_table.php
@@ -8,7 +8,7 @@ class CreateStoredEventsTable extends Migration
 {
     public function up(): void
     {
-        Schema::create('stored_events', function (Blueprint $table) {
+        Schema::connection('events')->create('stored_events', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->uuid('aggregate_uuid')->nullable();
             $table->unsignedBigInteger('aggregate_version')->nullable();
@@ -23,6 +23,6 @@ class CreateStoredEventsTable extends Migration
 
     public function down(): void
     {
-        Schema::drop('stored_events');
+        Schema::connection('events')->drop('stored_events');
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ networks:
 
 volumes:
   postgres:
+  pg_events:
+  pg_data:
   redis:
 
 services:
@@ -70,6 +72,36 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
       - ./docker/postgres/scripts:/usr/local/sbin
+    networks:
+      - nawhas
+  events_db:
+    image: postgres:11
+    container_name: nawhas_events_db
+    restart: unless-stopped
+    tty: true
+    ports:
+      - "5433:5432"
+    environment:
+      - POSTGRES_DB=nawhas_events
+      - POSTGRES_USER=docker
+      - POSTGRES_PASSWORD=secret
+    volumes:
+      - pg_events:/var/lib/postgresql/data
+    networks:
+      - nawhas
+  data_db:
+    image: postgres:11
+    container_name: nawhas_data_db
+    restart: unless-stopped
+    tty: true
+    ports:
+      - "5434:5432"
+    environment:
+      - POSTGRES_DB=nawhas_data
+      - POSTGRES_USER=docker
+      - POSTGRES_PASSWORD=secret
+    volumes:
+      - pg_data:/var/lib/postgresql/data
     networks:
       - nawhas
   cache:


### PR DESCRIPTION
Multiple Databases!!

`events` database stores our events. This will be shared across all production app instances.

`data` database will store our projected, read-only models by processing events.

`pgsql` database is the (now) "legacy" Doctrine database.


Run the following command to run database migrations for everything!
```
php artisan migrate:all
```