### PR TITLE
Fix request validations by specifying correct default database connection.

### DIFF
--- a/api/config/database.php
+++ b/api/config/database.php
@@ -1,7 +1,5 @@
 <?php
 
-use Illuminate\Support\Str;
-
 return [
 
     /*
@@ -15,7 +13,7 @@ return [
     |
     */
 
-    'default' => env('DB_CONNECTION', 'pgsql'),
+    'default' => env('DB_CONNECTION', 'data'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
This will tell Laravel to use the `data` database by default for all database related queries, like unique validation rules in Requests.