### PR TITLE
Use Laravel's presence verifier.

### DIFF
--- a/api/config/doctrine.php
+++ b/api/config/doctrine.php
@@ -203,7 +203,7 @@ return [
      |  Enables the Doctrine Presence Verifier for Validation
      |
      */
-    'doctrine_presence_verifier' => true,
+    'doctrine_presence_verifier' => false,
 
     /*
      |--------------------------------------------------------------------------


### PR DESCRIPTION
Stop using Doctrine's presence verifier.

Note that this will break all old FormRequest classes that use the `unique` or `exists` rule with the Doctrine syntax (`exists:App\Entities\User...`)