### PR TITLE
Setup Meilisearch for Local Dev

### DIFF
--- a/api/app/Console/Commands/Meilisearch/SetupScout.php
+++ b/api/app/Console/Commands/Meilisearch/SetupScout.php
@@ -11,7 +11,7 @@ class SetupScout extends Command
      *
      * @var string
      */
-    protected $signature = 'meilisearch:setup {--reset}';
+    protected $signature = 'meilisearch:setup {--reset} {--import}';
 
     /**
      * The console command description.
@@ -40,9 +40,12 @@ class SetupScout extends Command
             $this->call('scout:index', [
                'name' => $index
             ]);
-            $this->call('scout:import', [
-                'model' => $config['model'],
-            ]);
+
+            if ($this->option('import')) {
+                $this->call('scout:import', [
+                    'model' => $config['model'],
+                ]);
+            }
         }
 
         return 0;

--- a/api/composer.json
+++ b/api/composer.json
@@ -5,7 +5,6 @@
     "license": "MIT",
     "require": {
         "php": "7.4.*",
-        "algolia/scout-extended": "^1.9",
         "fideloper/proxy": "^4.0",
         "fruitcake/laravel-cors": "^2.0",
         "graham-campbell/github": "^9.1",

--- a/api/composer.lock
+++ b/api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "311f01470d196c0cecfaf1b398e10129",
+    "content-hash": "e026c9913602683ace01b122934df951",
     "packages": [
         {
             "name": "algolia/algoliasearch-client-php",
@@ -75,82 +75,6 @@
                 "search"
             ],
             "time": "2020-06-25T08:47:13+00:00"
-        },
-        {
-            "name": "algolia/scout-extended",
-            "version": "v1.9.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/algolia/scout-extended.git",
-                "reference": "1ca3d75c21f7dd8d209c044c1447cf54a7fba5c0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/algolia/scout-extended/zipball/1ca3d75c21f7dd8d209c044c1447cf54a7fba5c0",
-                "reference": "1ca3d75c21f7dd8d209c044c1447cf54a7fba5c0",
-                "shasum": ""
-            },
-            "require": {
-                "algolia/algoliasearch-client-php": "^2.5.1",
-                "ext-json": "*",
-                "illuminate/console": "^6.0|^7.0",
-                "illuminate/contracts": "^6.0|^7.0",
-                "illuminate/database": "^6.0|^7.0",
-                "illuminate/filesystem": "^6.0|^7.0",
-                "illuminate/support": "^6.0|^7.0",
-                "laravel/scout": "^8.0",
-                "php": "^7.2",
-                "riimu/kit-phpencoder": "^2.4"
-            },
-            "require-dev": {
-                "fzaninotto/faker": "^1.8",
-                "mockery/mockery": "^1.1",
-                "nunomaduro/larastan": "^0.5",
-                "orchestra/testbench": "^4.0|^5.0",
-                "phpstan/phpstan": "^0.12.14",
-                "phpunit/phpunit": "^8.0|^9.0"
-            },
-            "suggest": {
-                "ext-dom": "Required to use the HTML Splitter."
-            },
-            "type": "library",
-            "extra": {
-                "laravel": {
-                    "providers": [
-                        "Algolia\\ScoutExtended\\ScoutExtendedServiceProvider"
-                    ]
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Algolia\\ScoutExtended\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nuno Maduro",
-                    "email": "enunomaduro@gmail.com"
-                },
-                {
-                    "name": "Algolia Team",
-                    "email": "contact@algolia.com"
-                }
-            ],
-            "description": "Scout Extended extends Laravel Scout adding algolia-specific features",
-            "keywords": [
-                "algolia",
-                "analytics",
-                "extended",
-                "laravel",
-                "places",
-                "scout",
-                "search"
-            ],
-            "time": "2020-03-03T14:27:21+00:00"
         },
         {
             "name": "asm89/stack-cors",
@@ -5802,57 +5726,6 @@
                 }
             ],
             "time": "2020-07-28T16:51:01+00:00"
-        },
-        {
-            "name": "riimu/kit-phpencoder",
-            "version": "v2.4.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Riimu/Kit-PHPEncoder.git",
-                "reference": "7e876d25019c3f6c23321ab5ac1a55c72fcd0933"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Riimu/Kit-PHPEncoder/zipball/7e876d25019c3f6c23321ab5ac1a55c72fcd0933",
-                "reference": "7e876d25019c3f6c23321ab5ac1a55c72fcd0933",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.6.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^7.2 || ^6.5 || ^5.7"
-            },
-            "suggest": {
-                "ext-gmp": "To convert GMP numbers into PHP code"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Riimu\\Kit\\PHPEncoder\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Riikka Kalliomäki",
-                    "email": "riikka.kalliomaki@gmail.com",
-                    "homepage": "http://riimu.net"
-                }
-            ],
-            "description": "Highly customizable alternative to var_export for PHP code generation",
-            "homepage": "http://kit.riimu.net",
-            "keywords": [
-                "code",
-                "encoder",
-                "export",
-                "generator",
-                "variable"
-            ],
-            "time": "2018-07-03T12:46:23+00:00"
         },
         {
             "name": "sentry/sdk",
@@ -12298,6 +12171,57 @@
             "time": "2020-06-22T14:35:17+00:00"
         },
         {
+            "name": "riimu/kit-phpencoder",
+            "version": "v2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Riimu/Kit-PHPEncoder.git",
+                "reference": "7e876d25019c3f6c23321ab5ac1a55c72fcd0933"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Riimu/Kit-PHPEncoder/zipball/7e876d25019c3f6c23321ab5ac1a55c72fcd0933",
+                "reference": "7e876d25019c3f6c23321ab5ac1a55c72fcd0933",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.2 || ^6.5 || ^5.7"
+            },
+            "suggest": {
+                "ext-gmp": "To convert GMP numbers into PHP code"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Riimu\\Kit\\PHPEncoder\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Riikka Kalliomäki",
+                    "email": "riikka.kalliomaki@gmail.com",
+                    "homepage": "http://riimu.net"
+                }
+            ],
+            "description": "Highly customizable alternative to var_export for PHP code generation",
+            "homepage": "http://kit.riimu.net",
+            "keywords": [
+                "code",
+                "encoder",
+                "export",
+                "generator",
+                "variable"
+            ],
+            "time": "2018-07-03T12:46:23+00:00"
+        },
+        {
             "name": "scrivo/highlight.php",
             "version": "v9.18.1.1",
             "source": {
@@ -13506,5 +13430,5 @@
         "php": "7.4.*"
     },
     "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/api/config/meilisearch.php
+++ b/api/config/meilisearch.php
@@ -3,7 +3,7 @@
 $index = fn(string $name): string => env('SCOUT_PREFIX', '') . $name;
 
 return [
-    'host' => env('MEILISEARCH_HOST', 'nawhas_search:7700'),
+    'host' => env('MEILISEARCH_HOST', 'http://nawhas_search:7700'),
     'key' => env('MEILISEARCH_KEY', 'secret'),
 
     'indices' => [

--- a/docker/nginx/ingress.conf
+++ b/docker/nginx/ingress.conf
@@ -85,3 +85,47 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 }
+
+server {
+    listen 80;
+    listen [::]:80;
+
+    server_name search.nawhas.test;
+
+    access_log off;
+
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+
+    server_name search.nawhas.test;
+
+    ssl_certificate /etc/nginx/certs/search.nawhas.test.crt;
+    ssl_certificate_key /etc/nginx/certs/search.nawhas.test.key;
+
+    ssl_session_timeout 1d;
+    ssl_session_cache shared:SSL:50m;
+    ssl_session_tickets off;
+
+    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    ssl_prefer_server_ciphers on;
+
+    charset utf-8;
+    sendfile on;
+    client_max_body_size 100m;
+
+    access_log off;
+
+    location / {
+        proxy_pass http://nawhas_search:7700;
+        proxy_redirect off;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Host $server_name;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}


### PR DESCRIPTION
Adds https://search.nawhas.test as a new domain name. You'll need to generate a new certificate for this:

```
docker/nginx/certs
├── search.nawhas.test.crt
└── search.nawhas.test.key
```
I used the following command:

```
mkcert \
  --cert-file search.nawhas.test.crt \
  --key-file search.nawhas.test.key \
  search.nawhas.test localhost 127.0.0.1 10.0.0.60 ::1
```

Afterwards, you'll need to add `127.0.0.1 search.nawhas.test` to your hosts file as well.