### PR TITLE
Nuxt: Search Configuration

### DIFF
--- a/api/app/Console/Commands/Meilisearch/SetupMeilisearch.php
+++ b/api/app/Console/Commands/Meilisearch/SetupMeilisearch.php
@@ -3,8 +3,9 @@
 namespace App\Console\Commands\Meilisearch;
 
 use Illuminate\Console\Command;
+use MeiliSearch\Client as Meilisearch;
 
-class SetupScout extends Command
+class SetupMeilisearch extends Command
 {
     /**
      * The name and signature of the console command.
@@ -25,7 +26,7 @@ class SetupScout extends Command
      *
      * @return int
      */
-    public function handle()
+    public function handle(Meilisearch $client)
     {
         $indices = config('meilisearch.indices');
 
@@ -37,9 +38,13 @@ class SetupScout extends Command
                 ]);
             }
 
+            $this->comment("Creating index $index");
             $this->call('scout:index', [
                'name' => $index
             ]);
+
+            $client->getIndex($index)->updateSettings($config['settings']);
+            $this->comment("Pushed settings for index $index");
 
             if ($this->option('import')) {
                 $this->call('scout:import', [

--- a/api/app/Http/Controllers/Api/SearchController.php
+++ b/api/app/Http/Controllers/Api/SearchController.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Modules\Features\FeatureManager;
+use Illuminate\Http\JsonResponse;
+use MeiliSearch\Client as Search;
+
+class SearchController extends Controller
+{
+    private Search $search;
+
+    public function __construct(Search $search)
+    {
+        $this->search = $search;
+    }
+
+    public function key(): JsonResponse
+    {
+        $keys = $this->search->getKeys();
+
+        return $this->respondWithArray([
+            'data' => $keys['public'],
+        ]);
+    }
+}

--- a/api/app/Providers/AppServiceProvider.php
+++ b/api/app/Providers/AppServiceProvider.php
@@ -2,14 +2,12 @@
 
 namespace App\Providers;
 
-use App\Console\Commands\ImportDataCommand;
-use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Http\Resources\Json\JsonResource;
-use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Sanctum\Sanctum;
 use League\Fractal\Manager as Fractal;
 use League\Fractal\Serializer\ArraySerializer;
+use MeiliSearch\Client as Search;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -34,6 +32,8 @@ class AppServiceProvider extends ServiceProvider
 
             return $fractal;
         });
+
+        $this->app->bind(Search::class, fn () => new Search(config('meilisearch.host'), config('meilisearch.key')));
     }
 
     /**

--- a/api/config/meilisearch.php
+++ b/api/config/meilisearch.php
@@ -2,19 +2,40 @@
 
 $index = fn(string $name): string => env('SCOUT_PREFIX', '') . $name;
 
+
 return [
+    /*
+    |--------------------------------------------------------------------------
+    | Meilisearch Configuration
+    |--------------------------------------------------------------------------
+    | See https://github.com/meilisearch/meilisearch-laravel-scout
+    | Index Settings https://docs.meilisearch.com/references/settings.html#update-settings
+    */
     'host' => env('MEILISEARCH_HOST', 'nawhas_search:7700'),
     'key' => env('MEILISEARCH_KEY', 'secret'),
 
     'indices' => [
         $index('reciters') => [
             'model' => App\Modules\Library\Models\Reciter::class,
+            'settings' => [
+                'searchableAttributes' => ['name', 'description']
+            ],
         ],
         $index('albums') => [
             'model' => App\Modules\Library\Models\Album::class,
+            'settings' => [
+                'searchableAttributes' => ['title', 'year', 'reciter'],
+                'rankingRules' => ['typo', 'words', 'proximity', 'attribute', 'wordsPosition', 'exactness', 'desc(year)']
+            ],
         ],
         $index('tracks') => [
             'model' => App\Modules\Library\Models\Track::class,
+            'settings' => [
+                'searchableAttributes' => [
+                    'title', 'lyrics', 'year', 'reciter', 'album',
+                ],
+                'rankingRules' => ['typo', 'words', 'proximity', 'attribute', 'wordsPosition', 'exactness', 'desc(year)']
+            ],
         ],
     ],
 ];

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\Api\FeaturesController;
 use App\Http\Controllers\Api\FeedbackController;
 use App\Http\Controllers\Api\PopularEntitiesController;
+use App\Http\Controllers\Api\SearchController;
 use App\Modules\Features\Definitions\PublicUserRegistration;
 use App\Modules\Features\Http\Middleware\EnforceFeatureFlags;
 use Illuminate\Support\Facades\Route;
@@ -30,4 +31,6 @@ Route::prefix('v1')->group(function () {
         Route::get('secret', [FeaturesController::class, 'secret'])
             ->middleware(EnforceFeatureFlags::in([PublicUserRegistration::NAME]));
     });
+
+    Route::get('search/key', [SearchController::class, 'key']);
 });

--- a/nuxt/@types/nawhas/index.d.ts
+++ b/nuxt/@types/nawhas/index.d.ts
@@ -1,23 +1,28 @@
 import { InjectedApiPlugin } from '@/plugins/api';
+import MeiliSearch from 'meilisearch';
 
 declare module 'vue/types/vue' {
   interface Vue {
     $api: InjectedApiPlugin;
+    $search: MeiliSearch;
   }
 }
 
 declare module '@nuxt/types' {
   interface NuxtAppOptions {
     $api: InjectedApiPlugin;
+    $search: MeiliSearch;
   }
 
   interface Context {
     $api: InjectedApiPlugin;
+    $search: MeiliSearch;
   }
 }
 
 declare module 'vuex/types/index' {
   interface Store<S> {
     $api: InjectedApiPlugin;
+    $search: MeiliSearch;
   }
 }

--- a/nuxt/components/search/GlobalSearch.vue
+++ b/nuxt/components/search/GlobalSearch.vue
@@ -43,13 +43,13 @@
             background: $vuetify.theme.currentTheme.background,
           }"
         >
-          <index-results :client="client" :search="search" collection="reciters" heading="Reciters">
+          <index-results :client="$search" :search="search" collection="reciters" heading="Reciters">
             <reciter-result slot-scope="{ item }" :reciter="item" />
           </index-results>
-          <index-results :client="client" :search="search" collection="tracks" heading="Nawhas">
+          <index-results :client="$search" :search="search" collection="tracks" heading="Nawhas">
             <track-result slot-scope="{ item }" :track="item" />
           </index-results>
-          <index-results :client="client" :search="search" collection="albums" heading="Albums">
+          <index-results :client="$search" :search="search" collection="albums" heading="Albums">
             <album-result slot-scope="{ item }" :album="item" />
           </index-results>
           <div class="search__footer" :class="{ 'white--text': isDark }">
@@ -68,18 +68,11 @@
 
 <script lang="ts">
 import { Component, Vue, Prop, Ref, Watch } from 'nuxt-property-decorator';
-import MeiliSearch from 'meilisearch';
 import ClickOutside, { ClickOutsideConfiguration } from '@/directives/click-outside';
 import IndexResults from '@/components/search/IndexResults.vue';
 import ReciterResult from '@/components/search/ReciterResult.vue';
 import TrackResult from '@/components/search/TrackResult.vue';
 import AlbumResult from '@/components/search/AlbumResult.vue';
-
-declare global {
-  interface Window {
-    search: MeiliSearch;
-  }
-}
 
 @Component({
   components: {
@@ -93,7 +86,6 @@ declare global {
   },
 })
 export default class GlobalSearch extends Vue {
-  private client?: MeiliSearch;
   private activated = false;
   private focused = false;
   private search = '';
@@ -106,13 +98,6 @@ export default class GlobalSearch extends Vue {
 
   get isDark() {
     return this.$vuetify.theme.dark;
-  }
-
-  created() {
-    this.client = new MeiliSearch({
-      host: this.$config.searchHost,
-      apiKey: 'secret',
-    });
   }
 
   @Watch('$route')

--- a/nuxt/nuxt.config.js
+++ b/nuxt/nuxt.config.js
@@ -101,6 +101,7 @@ export default {
     '@/plugins/axios',
     '@/plugins/filters',
     '@/plugins/api',
+    '@/plugins/search',
     '@/plugins/theme.client',
     '@/plugins/service-worker.client',
   ],

--- a/nuxt/plugins/search.ts
+++ b/nuxt/plugins/search.ts
@@ -1,0 +1,17 @@
+import { Plugin } from '@nuxt/types';
+import MeiliSearch from 'meilisearch';
+
+interface KeyResponse {
+  data: string;
+}
+
+const SearchPlugin: Plugin = async ({ $axios, $config }, inject) => {
+  const response = await $axios.$get<KeyResponse>('v1/search/key');
+
+  inject('search', new MeiliSearch({
+    host: $config.searchHost,
+    apiKey: response.data,
+  }));
+};
+
+export default SearchPlugin;


### PR DESCRIPTION
This PR sets up index settings in the API backend, and exposes a new API route (`GET v1/search/key`) to fetch the public key used for Meilisearch. Nuxt then consumes this endpoint during the server side render process and injects Meilisearch into the context as `$search`.