### PR TITLE
Nuxt: Add better metadata to all pages.

### DIFF
--- a/nuxt/nuxt.config.js
+++ b/nuxt/nuxt.config.js
@@ -3,6 +3,7 @@ import path from 'path';
 require('dotenv').config();
 
 const TITLE_SUFFIX = 'Nawhas.com';
+const TITLE_TEMPLATE = '%s | ' + TITLE_SUFFIX;
 const DEFAULT_DESCRIPTION = 'Welcome to Nawhas.com, the most advanced library of nawhas online.';
 
 const https = process.env.APP_ENV === 'development' ? {
@@ -48,12 +49,14 @@ export default {
   ** See https://nuxtjs.org/api/configuration-head
   */
   head: {
-    titleTemplate: '%s | ' + TITLE_SUFFIX,
+    titleTemplate: TITLE_TEMPLATE,
     title: 'Home',
     meta: [
       { charset: 'utf-8' },
       { name: 'viewport', content: 'width=device-width, initial-scale=1' },
       { hid: 'description', name: 'description', content: DEFAULT_DESCRIPTION },
+      { hid: 'og:title', property: 'og:title', template: TITLE_TEMPLATE },
+      { hid: 'og:description', name: 'og:description', content: DEFAULT_DESCRIPTION },
     ],
     link: [
       { rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' },

--- a/nuxt/pages/AboutPage.vue
+++ b/nuxt/pages/AboutPage.vue
@@ -124,6 +124,7 @@ import Vue from 'vue';
 import HeroBanner from '@/components/HeroBanner.vue';
 import HeroQuote from '@/components/HeroQuote.vue';
 import { mdiGithub } from '@mdi/js';
+import { generateMeta } from '@/utils/meta';
 
 export default Vue.extend({
   components: {
@@ -228,9 +229,10 @@ export default Vue.extend({
     },
   },
 
-  head: {
+  head: () => generateMeta({
     title: 'About',
-  },
+    description: 'Learn about the history behind Nawhas.com, and our plans for the future.',
+  }),
 });
 </script>
 

--- a/nuxt/pages/AlbumPage.vue
+++ b/nuxt/pages/AlbumPage.vue
@@ -127,6 +127,7 @@ import { Reciter, getReciterUri } from '@/entities/reciter';
 import TrackList from '@/components/tracks/TrackList.vue';
 import EditTrackDialog from '@/components/edit/EditTrackDialog.vue';
 import EditAlbumDialog from '@/components/edit/EditAlbumDialog.vue';
+import { generateMeta } from '@/utils/meta';
 
 interface Data {
   album: Album | null;
@@ -262,12 +263,21 @@ export default Vue.extend({
 
   head(): MetaInfo {
     let title = `${this.$route.params.albumId} Album`;
+    let description;
 
     if (this.album) {
       title = `${this.album.title} (${this.album.year}) - Album by ${this.album.reciter?.name}`;
+
+      const trackListPreview = this.tracks?.slice(0, 3).map((track) => track.title).join(', ');
+      description = `Released in ${this.album.year}, ${this.album.title} is an album by ` +
+        `${this.album.reciter?.name} with ${this.album.related?.tracks} nawhas, including ` +
+        `${trackListPreview}, and more.`;
     }
 
-    return { title };
+    return generateMeta({
+      title,
+      description,
+    });
   },
 });
 </script>

--- a/nuxt/pages/ReciterProfilePage.vue
+++ b/nuxt/pages/ReciterProfilePage.vue
@@ -115,6 +115,8 @@ import Album from '@/components/albums/Album.vue';
 import { TrackIncludes } from '@/api/tracks';
 import EditReciterDialog from '@/components/edit/EditReciterDialog.vue';
 import EditAlbumDialog from '@/components/edit/EditAlbumDialog.vue';
+import { generateMeta } from '@/utils/meta';
+import { ReciterIncludes } from '@/api/reciters';
 
 interface Data {
   page: number;
@@ -139,7 +141,9 @@ export default Vue.extend({
   async fetch() {
     const { reciterId } = this.$route.params;
     const [reciter, tracks, albums] = await Promise.all([
-      this.$api.reciters.get(reciterId),
+      this.$api.reciters.get(reciterId, {
+        include: [ReciterIncludes.Related],
+      }),
       this.$api.tracks.popular({
         reciterId,
         pagination: { limit: 6 },
@@ -198,10 +202,17 @@ export default Vue.extend({
 
   head(): MetaInfo {
     const title = this.reciter?.name ?? 'Reciter';
+    let description = this.reciter?.description;
 
-    return {
+    if (!description) {
+      const albums = String(this.reciter?.related?.albums ?? 'many');
+      description = `Explore ${title}'s collection of nawhas from ${albums} albums.`;
+    }
+
+    return generateMeta({
       title,
-    };
+      description,
+    });
   },
 });
 </script>

--- a/nuxt/pages/RecitersListPage.vue
+++ b/nuxt/pages/RecitersListPage.vue
@@ -60,6 +60,7 @@ import SkeletonCardGrid from '@/components/loaders/SkeletonCardGrid.vue';
 import { EventBus, Search } from '@/events';
 import { ReciterIncludes, RecitersIndexResponse } from '@/api/reciters';
 import { Reciter } from '@/entities/reciter';
+import { generateMeta } from '@/utils/meta';
 
 interface Data {
   page: number;
@@ -120,9 +121,12 @@ export default Vue.extend({
     },
   },
 
-  head: {
+  head: () => generateMeta({
     title: 'Reciters',
-  },
+    description: 'Browse, read, and listen to over 6000 nawhas by more than 100 different reciters, ' +
+       'including world-famous reciters like Nadeem Sarwar, Irfan Haider, Tejani Brothers, ' +
+       'Hassan Sadiq, Mir Hasan Mir, and more!',
+  }),
 });
 </script>
 

--- a/nuxt/pages/TrackPage.vue
+++ b/nuxt/pages/TrackPage.vue
@@ -169,6 +169,7 @@ import { Reciter, getReciterUri } from '@/entities/reciter';
 import { Album, getAlbumArtwork, getAlbumUri } from '@/entities/album';
 import { TrackIncludes } from '@/api/tracks';
 import { MetaInfo } from 'vue-meta';
+import { generateMeta } from '@/utils/meta';
 
 interface Data {
   track: Track | null;
@@ -346,12 +347,19 @@ export default Vue.extend({
 
   head(): MetaInfo {
     let title = 'Loading...';
+    let description;
 
     if (this.track) {
       title = `${this.track.title} (${this.track.year}) - Nawha by ${this.track.reciter?.name}`;
+
+      description = `${this.track.title} is a nawha by ${this.track.reciter?.name}, released in ${this.track.year} ` +
+        `as part of their album titled ${this.track.album?.title}.`;
     }
 
-    return { title };
+    return generateMeta({
+      title,
+      description,
+    });
   },
 });
 </script>

--- a/nuxt/store/features.ts
+++ b/nuxt/store/features.ts
@@ -1,6 +1,6 @@
 import { ActionContext, ActionTree, MutationTree, GetterTree } from 'vuex';
 import { Feature, FeatureMap } from '@/entities/feature';
-import { RootState } from '~/store/index';
+import { RootState } from '@/store/index';
 
 /*
 |--------------------------------------------------------------------------

--- a/nuxt/utils/meta.ts
+++ b/nuxt/utils/meta.ts
@@ -1,0 +1,36 @@
+import { MetaInfo, MetaPropertyProperty, MetaPropertyName } from 'vue-meta';
+
+interface MetaOptions {
+  title: string;
+  description?: string;
+}
+
+export function generateMeta({ title, description } : MetaOptions): MetaInfo {
+  const meta: (MetaPropertyProperty|MetaPropertyName)[] = [
+    {
+      hid: 'og:title',
+      property: 'og:title',
+      content: title,
+    },
+  ];
+
+  if (description) {
+    meta.push(
+      {
+        hid: 'description',
+        name: 'description',
+        content: description,
+      },
+      {
+        hid: 'og:description',
+        property: 'og:description',
+        content: description,
+      },
+    );
+  }
+
+  return {
+    title,
+    meta,
+  };
+}


### PR DESCRIPTION
This PR adds open graph meta tags using a helper method to each of the pages we care about. The content below applies to both the `<title>` and `<meta name="description">` tags,  as well as `og:title` and `og:description`.

#### Reciters List Page
> **Reciters | Nawhas.com**
> Browse, read, and listen to over 6000 nawhas by more than 100 different reciters, including world-famous nawhakhwans like Nadeem Sarwar, Irfan Haider, Tejani Brothers, Hassan Sadiq, Mir Hasan Mir, and more!

#### Reciter Profile Page
> **Tejani Brothers | Nawhas.com**
> Explore Tejani Brothers&#x27;s collection of nawhas from 15 albums.

#### Album Page
> **Shia (2019) - Album by Tejani Brothers | Nawhas.com**
> Released in 2019, Shia is an album by Tejani Brothers with 9 nawhas, including Akbar Tere Jigar Se, Ark of Salvation (English), Day of Ashura (English), and more.

#### Track Page
> **Shame Ghariban (2019) - Nawha by Tejani Brothers | Nawhas.com**
> Shame Ghariban is a nawha by Tejani Brothers, released in 2019 as part of their album titled Shia.

Closes #293. Closes #242.