### PR TITLE
Added image to Reciter page, Album page and Track page

### DIFF
--- a/nuxt/pages/AlbumPage.vue
+++ b/nuxt/pages/AlbumPage.vue
@@ -264,6 +264,7 @@ export default Vue.extend({
   head(): MetaInfo {
     let title = `${this.$route.params.albumId} Album`;
     let description;
+    const image = getAlbumArtwork(this.album);
 
     if (this.album) {
       title = `${this.album.title} (${this.album.year}) - Album by ${this.album.reciter?.name}`;
@@ -277,6 +278,7 @@ export default Vue.extend({
     return generateMeta({
       title,
       description,
+      image,
     });
   },
 });

--- a/nuxt/pages/ReciterProfilePage.vue
+++ b/nuxt/pages/ReciterProfilePage.vue
@@ -203,6 +203,7 @@ export default Vue.extend({
   head(): MetaInfo {
     const title = this.reciter?.name ?? 'Reciter';
     let description = this.reciter?.description;
+    const image = getReciterAvatar(this.reciter);
 
     if (!description) {
       const albums = String(this.reciter?.related?.albums ?? 'many');
@@ -212,6 +213,7 @@ export default Vue.extend({
     return generateMeta({
       title,
       description,
+      image,
     });
   },
 });

--- a/nuxt/pages/TrackPage.vue
+++ b/nuxt/pages/TrackPage.vue
@@ -348,6 +348,7 @@ export default Vue.extend({
   head(): MetaInfo {
     let title = 'Loading...';
     let description;
+    const image = getAlbumArtwork(this.track?.album);
 
     if (this.track) {
       title = `${this.track.title} (${this.track.year}) - Nawha by ${this.track.reciter?.name}`;
@@ -359,6 +360,7 @@ export default Vue.extend({
     return generateMeta({
       title,
       description,
+      image,
     });
   },
 });

--- a/nuxt/utils/meta.ts
+++ b/nuxt/utils/meta.ts
@@ -3,9 +3,10 @@ import { MetaInfo, MetaPropertyProperty, MetaPropertyName } from 'vue-meta';
 interface MetaOptions {
   title: string;
   description?: string;
+  image?: string;
 }
 
-export function generateMeta({ title, description } : MetaOptions): MetaInfo {
+export function generateMeta({ title, description, image } : MetaOptions): MetaInfo {
   const meta: (MetaPropertyProperty|MetaPropertyName)[] = [
     {
       hid: 'og:title',
@@ -25,6 +26,16 @@ export function generateMeta({ title, description } : MetaOptions): MetaInfo {
         hid: 'og:description',
         property: 'og:description',
         content: description,
+      },
+    );
+  }
+
+  if (image) {
+    meta.push(
+      {
+        hid: 'og:image',
+        property: 'og:image',
+        content: image,
       },
     );
   }


### PR DESCRIPTION
This change adds the avatar/artwork on the following pages

`ReciterProfilePage` -> adds the Reciter Avatar if it has one, otherwise displays the default avatar
`AlbumPage` as well as `TrackPage` -> adds the album artwork if it has one, otherwise displays the default artwork

Closes #305 