### PR TITLE
Nuxt: Fix dark mode first render.

### DIFF
--- a/nuxt/entities/theme.ts
+++ b/nuxt/entities/theme.ts
@@ -1,4 +1,0 @@
-export type Theme = 'light'|'dark'|'auto';
-
-export const THEME_PREFERENCE_STORAGE_KEY = 'theme:preference';
-export const THEME_APPLIED_STORAGE_KEY = 'theme:applied';

--- a/nuxt/layouts/default.vue
+++ b/nuxt/layouts/default.vue
@@ -87,6 +87,8 @@ import UserMenu from '@/components/navigation/UserMenu.vue';
 import AudioPlayer from '@/components/audio-player/AudioPlayer.vue';
 import GlobalSearch from '@/components/search/GlobalSearch.vue';
 import UpdateServiceWorker from '@/components/utils/UpdateServiceWorker.vue';
+import { applyTheme } from '@/services/theme';
+
 const LogoIcon = require('@/assets/svg/icon.svg?inline');
 const LogoWordmark = require('@/assets/svg/wordmark.svg?inline');
 
@@ -140,6 +142,10 @@ export default Vue.extend({
         'app--player-showing': this.$store.getters['player/track'] !== null,
       };
     },
+  },
+
+  mounted() {
+    applyTheme(this.$store.state.preferences.theme, this.$vuetify, this.$storage);
   },
 });
 </script>

--- a/nuxt/nuxt.config.js
+++ b/nuxt/nuxt.config.js
@@ -10,6 +10,15 @@ const https = process.env.APP_ENV === 'development' ? {
   cert: fs.readFileSync(path.resolve(__dirname, '../docker/nginx/certs/nawhas.test.crt')),
 } : false;
 
+const proxy = process.env.PROXY_API ? {
+  // For local dev only
+  '/api': {
+    target: 'https://api.nawhas.test/',
+    pathRewrite: { '^/api': '' },
+    secure: false,
+  },
+} : {};
+
 export default {
   debug: true,
   /*
@@ -126,6 +135,7 @@ export default {
   modules: [
     // Doc: https://axios.nuxtjs.org/usage
     '@nuxtjs/universal-storage',
+    '@nuxtjs/proxy',
     '@nuxtjs/axios',
     '@nuxtjs/pwa',
   ],
@@ -134,7 +144,6 @@ export default {
   ** See https://axios.nuxtjs.org/options
   */
   axios: {
-    debug: false,
     credentials: true,
     headers: {
       common: {
@@ -235,4 +244,10 @@ export default {
     name: 'slide-x-transition',
     mode: 'out-in',
   },
+
+  /*
+   ** Proxy Settings
+   ** See https://github.com/nuxt-community/proxy-module#proxy
+   */
+  proxy,
 };

--- a/nuxt/package.json
+++ b/nuxt/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "nuxt-ts",
+    "dev:proxy": "cross-env PROXY_API=1 SERVER_API_BASE_URL=https://api.nawhas.test/ API_BASE_URL=/api/ nuxt-ts",
     "serve": "yarn dev",
     "build": "nuxt-ts build",
     "start": "nuxt-ts start",
@@ -24,6 +25,7 @@
     "@mdi/js": "^5.5.55",
     "@nuxt/typescript-runtime": "^1.0.0",
     "@nuxtjs/axios": "^5.12.0",
+    "@nuxtjs/proxy": "^2.0.1",
     "@nuxtjs/pwa": "^3.0.0-beta.20",
     "@nuxtjs/universal-storage": "^0.5.5",
     "@nuxtjs/vuetify": "^1.11.2",

--- a/nuxt/services/theme.ts
+++ b/nuxt/services/theme.ts
@@ -1,0 +1,35 @@
+import { Framework } from 'vuetify';
+import { NuxtStorage } from '@nuxtjs/universal-storage';
+
+export type Theme = 'light'|'dark'|'auto';
+
+export const THEME_PREFERENCE_STORAGE_KEY = 'theme:preference';
+export const THEME_APPLIED_STORAGE_KEY = 'theme:applied';
+
+export function shouldUseDarkMode(preference: Theme): boolean {
+  if (preference === 'dark') {
+    return true;
+  }
+
+  if (preference === 'auto' && process.browser && window.matchMedia) {
+    // This will check to see if the user has Dark Mode on their OS
+    return window.matchMedia('(prefers-color-scheme: dark)').matches;
+  }
+
+  return false;
+}
+
+export function saveAppliedTheme($vuetify: Framework, $storage: NuxtStorage) {
+  const applied: Theme = $vuetify.theme.dark ? 'dark' : 'light';
+  console.log('Saving applied theme:', applied);
+  $storage.setUniversal(THEME_APPLIED_STORAGE_KEY, applied);
+}
+
+export function applyTheme(theme: Theme, $vuetify: Framework, $storage: NuxtStorage) {
+  // Set vuetify theme.
+  $vuetify.theme.dark = shouldUseDarkMode(theme);
+  console.log('Determined new theme:', $vuetify.theme.dark ? 'dark' : 'light');
+
+  // Set last applied theme in storage.
+  saveAppliedTheme($vuetify, $storage);
+}

--- a/nuxt/store/preferences.ts
+++ b/nuxt/store/preferences.ts
@@ -1,5 +1,5 @@
 import { MutationTree } from 'vuex';
-import { Theme } from '@/entities/theme';
+import { Theme } from '@/services/theme';
 
 interface PreferencesState {
   theme: Theme;

--- a/nuxt/vuetify.options.ts
+++ b/nuxt/vuetify.options.ts
@@ -2,7 +2,7 @@ import { Context } from '@nuxt/types';
 import colors from 'vuetify/es5/util/colors';
 import { UserVuetifyPreset } from 'vuetify';
 import { parse as parseCookie } from 'cookie';
-import { THEME_APPLIED_STORAGE_KEY } from '@/entities/theme';
+import { THEME_APPLIED_STORAGE_KEY } from '@/services/theme';
 
 export default function options({ req }: Context): Partial<UserVuetifyPreset> {
   const cookie = process.client ? document.cookie : req.headers.cookie || '';


### PR DESCRIPTION
By moving the actual step of applying the theme to Vuetify to the layout `mounted()` hook, we can be sure that the theme is applied properly and uniformly across the board.

