### PR TITLE
Refresh CSRF cookie when request fails with 419.

### DIFF
--- a/nuxt/api/auth.ts
+++ b/nuxt/api/auth.ts
@@ -24,7 +24,6 @@ export class AuthApi {
   ) {}
 
   async login(payload: LoginPayload): Promise<User> {
-    await this.axios.get('/sanctum/csrf-cookie');
     return await this.axios.$post<User>('v1/auth/login', payload);
   }
 

--- a/nuxt/package.json
+++ b/nuxt/package.json
@@ -30,6 +30,7 @@
     "@nuxtjs/sentry": "^4.3.4",
     "@nuxtjs/universal-storage": "^0.5.5",
     "@nuxtjs/vuetify": "^1.11.2",
+    "axios-auth-refresh": "^2.2.8",
     "dotenv": "^8.2.0",
     "lazysizes": "^5.2.2",
     "meilisearch": "^0.12.0",

--- a/nuxt/plugins/axios.ts
+++ b/nuxt/plugins/axios.ts
@@ -1,7 +1,20 @@
 import https from 'https';
+import createAuthRefreshInterceptor from 'axios-auth-refresh';
 
 export default function ({ $axios, $config }) {
   if ($config.ignoreSslErrors) {
     $axios.defaults.httpsAgent = new https.Agent({ rejectUnauthorized: false });
   }
+
+  const onAxiosRequestFailure = async (failure) => {
+    if (failure.response.status === 419) {
+      await $axios.get('/sanctum/csrf-cookie');
+    }
+
+    return Promise.resolve();
+  };
+
+  createAuthRefreshInterceptor($axios, onAxiosRequestFailure, {
+    statusCodes: [419],
+  });
 }

--- a/nuxt/yarn.lock
+++ b/nuxt/yarn.lock
@@ -3147,6 +3147,11 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.10.0.tgz#a17b3a8ea811060e74d47d306122400ad4497ae2"
   integrity sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==
 
+axios-auth-refresh@^2.2.8:
+  version "2.2.8"
+  resolved "https://registry.yarnpkg.com/axios-auth-refresh/-/axios-auth-refresh-2.2.8.tgz#de420b6b5d6efdb4ad3666e44c38960a9b08f382"
+  integrity sha512-WR59uCgO9VppC9VQU6vtszrAHnF3RtylkGltOGldfB4Rw+my0j9WdJuvRzMwiwTh+LmG/SQWzgeCfFYf8N4FIA==
+
 axios-retry@^3.1.8:
   version "3.1.8"
   resolved "https://registry.yarnpkg.com/axios-retry/-/axios-retry-3.1.8.tgz#ffcfed757e1fab8cbf832f8505bb0e0af47c520c"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/379169/90809353-59ceaf00-e2ef-11ea-94df-06db67623fa6.png)

Auto-refresh CSRF if a failure is 419 CSRF Token Mismatch