### PR TITLE
Fix cache for library saved tracks.

### DIFF
--- a/api/app/Http/Kernel.php
+++ b/api/app/Http/Kernel.php
@@ -41,7 +41,6 @@ class Kernel extends HttpKernel
             \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
             // 'throttle:60,1', // TODO - Make this work with proxies.
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
-            \Spatie\ResponseCache\Middlewares\CacheResponse::class,
         ],
     ];
 

--- a/api/app/Infrastructure/Cache/Middleware/CacheResponse.php
+++ b/api/app/Infrastructure/Cache/Middleware/CacheResponse.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Cache\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Spatie\ResponseCache\Middlewares\CacheResponse as BaseCacheResponse;
+use Symfony\Component\HttpFoundation\Response;
+use TiMacDonald\Middleware\HasParameters;
+
+class CacheResponse
+{
+    use HasParameters;
+
+    private BaseCacheResponse $wrapped;
+
+    public function __construct(BaseCacheResponse $wrapped)
+    {
+        $this->wrapped = $wrapped;
+    }
+
+    public function handle(Request $request, Closure $next, string ...$tags): Response
+    {
+        return $this->wrapped->handle($request, $next, ...$tags);
+    }
+
+    public static function withTags(string ...$tags): string
+    {
+        return self::with([
+            'tags' => $tags,
+        ]);
+    }
+}

--- a/api/app/Infrastructure/Cache/Middleware/ClearResponseCache.php
+++ b/api/app/Infrastructure/Cache/Middleware/ClearResponseCache.php
@@ -8,9 +8,12 @@ use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Spatie\ResponseCache\ResponseCache;
+use TiMacDonald\Middleware\HasParameters;
 
 class ClearResponseCache
 {
+    use HasParameters;
+
     protected ResponseCache $manager;
 
     public function __construct(ResponseCache $responseCache)
@@ -18,15 +21,20 @@ class ClearResponseCache
         $this->manager = $responseCache;
     }
 
-    public function handle(Request $request, Closure $next)
+    public function handle(Request $request, Closure $next, string ...$tags)
     {
         /** @var Response $response */
         $response = $next($request);
 
         if ($response->isSuccessful()) {
-            $this->manager->clear();
+            $this->manager->clear($tags);
         }
 
         return $response;
-     }
+    }
+
+    public static function withTags(string ...$tags): string
+    {
+        return self::with(['tags' => $tags]);
+    }
 }

--- a/api/app/Modules/Accounts/Http/CacheTags.php
+++ b/api/app/Modules/Accounts/Http/CacheTags.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Modules\Accounts\Http;
+
+final class CacheTags
+{
+    public const SAVED_TRACKS = 'responses.accounts.tracks';
+}

--- a/api/app/Modules/Accounts/Http/api.php
+++ b/api/app/Modules/Accounts/Http/api.php
@@ -1,5 +1,8 @@
 <?php
 
+use App\Infrastructure\Cache\Middleware\CacheResponse;
+use App\Infrastructure\Cache\Middleware\ClearResponseCache;
+use App\Modules\Accounts\Http\CacheTags;
 use App\Modules\Accounts\Http\Controllers;
 use Illuminate\Support\Facades\Route;
 
@@ -10,9 +13,15 @@ Route::prefix('v1')->group(function () {
     |--------------------------------------------------------------------------
     */
     Route::prefix('me')->middleware('auth:sanctum')->group(function () {
-        Route::get('/tracks', [Controllers\LibraryController::class, 'tracks']);
-        Route::get('/tracks/ids', [Controllers\LibraryController::class, 'getTrackIds']);
-        Route::put('/tracks', [Controllers\LibraryController::class, 'saveTracks']);
+        Route::get('/tracks', [Controllers\LibraryController::class, 'tracks'])
+            ->middleware(CacheResponse::withTags(CacheTags::SAVED_TRACKS));
+
+        Route::get('/tracks/ids', [Controllers\LibraryController::class, 'getTrackIds'])
+            ->middleware(CacheResponse::withTags(CacheTags::SAVED_TRACKS));;
+
+        Route::put('/tracks', [Controllers\LibraryController::class, 'saveTracks'])
+            ->middleware(ClearResponseCache::withTags(CacheTags::SAVED_TRACKS));
+
         Route::delete('/tracks', [Controllers\LibraryController::class, 'removeSavedTracks']);
     });
 });

--- a/api/app/Modules/Authentication/Http/CacheTags.php
+++ b/api/app/Modules/Authentication/Http/CacheTags.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Modules\Authentication\Http;
+
+final class CacheTags
+{
+    public const USER = 'responses.auth.user';
+}

--- a/api/app/Modules/Authentication/Http/api.php
+++ b/api/app/Modules/Authentication/Http/api.php
@@ -1,8 +1,10 @@
 <?php
 
+use App\Infrastructure\Cache\Middleware\CacheResponse;
 use App\Modules\Authentication\Http\Controllers;
 use App\Modules\Features\Definitions\PublicUserRegistration;
 use App\Modules\Features\Http\Middleware\EnforceFeatureFlags;
+use App\Modules\Authentication\Http\CacheTags;
 use Illuminate\Support\Facades\Route;
 
 Route::prefix('v1')->group(function () {
@@ -13,9 +15,14 @@ Route::prefix('v1')->group(function () {
     */
     Route::prefix('auth')->group(function () {
         Route::post('login', [Controllers\AuthController::class, 'login']);
+
         Route::post('register', [Controllers\AuthController::class, 'register'])
             ->middleware(EnforceFeatureFlags::in([PublicUserRegistration::NAME]));
+
         Route::post('logout', [Controllers\AuthController::class, 'logout'])->middleware('auth:sanctum');
-        Route::get('user', [Controllers\AuthController::class, 'user'])->middleware('auth:sanctum');
+
+        Route::get('user', [Controllers\AuthController::class, 'user'])
+            ->middleware('auth:sanctum')
+            ->middleware(CacheResponse::withTags(CacheTags::USER));
     });
 });

--- a/api/app/Modules/Library/Http/CacheTags.php
+++ b/api/app/Modules/Library/Http/CacheTags.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Modules\Library\Http;
+
+final class CacheTags
+{
+    public const LIBRARY = 'responses.library';
+}

--- a/api/app/Modules/Library/Http/api.php
+++ b/api/app/Modules/Library/Http/api.php
@@ -1,9 +1,13 @@
 <?php
 
+use App\Infrastructure\Cache\Middleware\CacheResponse;
+use App\Infrastructure\Cache\Middleware\ClearResponseCache;
+use App\Modules\Accounts\Http\CacheTags as AccountsCacheTags;
+use App\Modules\Library\Http\CacheTags;
 use App\Modules\Library\Http\Controllers;
 use Illuminate\Support\Facades\Route;
 
-Route::prefix('v1')->group(function () {
+Route::prefix('v1')->middleware(CacheResponse::withTags(CacheTags::LIBRARY))->group(function () {
     /*
     |--------------------------------------------------------------------------
     | Reciter Routes
@@ -13,7 +17,10 @@ Route::prefix('v1')->group(function () {
         Route::get('/', [Controllers\RecitersController::class, 'index']);
         Route::get('/{reciter}', [Controllers\RecitersController::class, 'show']);
 
-        Route::middleware(['auth:sanctum', 'cache.clear'])->group(function () {
+        Route::middleware([
+            'auth:sanctum',
+            ClearResponseCache::withTags(CacheTags::LIBRARY, AccountsCacheTags::SAVED_TRACKS)
+        ])->group(function () {
             Route::post('/', [Controllers\RecitersController::class, 'store']);
             Route::patch('/{reciter}', [Controllers\RecitersController::class, 'update']);
             Route::post('/{reciter}/avatar', [Controllers\RecitersController::class, 'uploadAvatar']);
@@ -30,7 +37,10 @@ Route::prefix('v1')->group(function () {
         Route::get('/', [Controllers\AlbumsController::class, 'index']);
         Route::get('/{album:year}', [Controllers\AlbumsController::class, 'show']);
 
-        Route::middleware(['auth:sanctum', 'cache.clear'])->group(function () {
+        Route::middleware([
+            'auth:sanctum',
+            ClearResponseCache::withTags(CacheTags::LIBRARY, AccountsCacheTags::SAVED_TRACKS)
+        ])->group(function () {
             Route::post('/', [Controllers\AlbumsController::class, 'store']);
             Route::patch('/{album:year}', [Controllers\AlbumsController::class, 'update']);
             Route::post('/{album:year}/artwork', [Controllers\AlbumsController::class, 'uploadArtwork']);
@@ -47,7 +57,10 @@ Route::prefix('v1')->group(function () {
         Route::get('/', [Controllers\TracksController::class, 'index']);
         Route::get('/{track:slug}', [Controllers\TracksController::class, 'show']);
 
-        Route::middleware(['auth:sanctum', 'cache.clear'])->group(function () {
+        Route::middleware([
+            'auth:sanctum',
+            ClearResponseCache::withTags(CacheTags::LIBRARY, AccountsCacheTags::SAVED_TRACKS)
+        ])->group(function () {
             Route::post('/', [Controllers\TracksController::class, 'store']);
             Route::patch('/{track:slug}', [Controllers\TracksController::class, 'update']);
             Route::post('/{track:slug}/media/audio', [Controllers\TracksController::class, 'uploadTrackMedia']);


### PR DESCRIPTION
Using cache tags, I can make sure to clear the right pieces of cached responses so that the saved tracks responses are cached, but only those are invalidated when saving a new track.