### PR TITLE
Add projector for incrementing track statistics to fix super slow query.

### DIFF
--- a/api/app/Modules/Authentication/Models/User.php
+++ b/api/app/Modules/Authentication/Models/User.php
@@ -36,6 +36,8 @@ use Ramsey\Uuid\Uuid;
  * @method static \Illuminate\Database\Eloquent\Builder|\App\Modules\Authentication\Models\User newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|\App\Modules\Authentication\Models\User query()
  * @mixin \Eloquent
+ * @property-read \Illuminate\Database\Eloquent\Collection|Track[] $savedTracks
+ * @property-read int|null $saved_tracks_count
  */
 class User extends Authenticatable implements TimestampedEntity
 {

--- a/api/app/Modules/Library/Models/Track.php
+++ b/api/app/Modules/Library/Models/Track.php
@@ -13,10 +13,13 @@ use App\Modules\Library\Events\Tracks\TrackCreated;
 use App\Modules\Library\Events\Tracks\TrackLyricsChanged;
 use App\Modules\Library\Events\Tracks\TrackTitleChanged;
 use App\Modules\Library\Models\Traits\Visitable;
+use App\Modules\Library\Models\Visits\TrackStatistic;
 use App\Modules\Lyrics\Documents\Document;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Laravel\Scout\Searchable;
 use Ramsey\Uuid\Uuid;
 use Spatie\Sluggable\HasSlug;
@@ -48,6 +51,7 @@ use Spatie\Sluggable\SlugOptions;
  * @method static \Illuminate\Database\Eloquent\Builder|\App\Modules\Library\Models\Track popularMonth()
  * @method static \Illuminate\Database\Eloquent\Builder|\App\Modules\Library\Models\Track popularWeek()
  * @method static \Illuminate\Database\Eloquent\Builder|\App\Modules\Library\Models\Track popularYear()
+ * @property-read TrackStatistic|null $statistics
  */
 class Track extends Model implements TimestampedEntity
 {
@@ -124,6 +128,11 @@ class Track extends Model implements TimestampedEntity
         return $this->belongsTo(Album::class);
     }
 
+    public function statistics(): HasOne
+    {
+        return $this->hasOne(TrackStatistic::class);
+    }
+
     public function getSlugOptions(): SlugOptions
     {
         return SlugOptions::create()
@@ -180,5 +189,16 @@ class Track extends Model implements TimestampedEntity
                 ),
             ],
         ];
+    }
+
+    /**
+     * Filter by popular in all time
+     * @param $query
+     * @return mixed
+     */
+    public function scopePopularAllTime(Builder $query)
+    {
+        return $query->join('track_statistics', 'track_statistics.track_id', '=', 'tracks.id')
+            ->orderBy('track_statistics.visits_all_time', 'desc');
     }
 }

--- a/api/app/Modules/Library/Models/Visits/TrackStatistic.php
+++ b/api/app/Modules/Library/Models/Visits/TrackStatistic.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Modules\Library\Models\Visits;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * App\Modules\Library\Models\Visits\TrackStatistic
+ *
+ * @property string $track_id
+ * @property int $visits_all_time
+ * @method static \Illuminate\Database\Eloquent\Builder|TrackStatistic newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|TrackStatistic newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|TrackStatistic query()
+ * @mixin \Eloquent
+ */
+class TrackStatistic extends Model
+{
+    protected $table = 'track_statistics';
+
+    protected $primaryKey = 'track_id';
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'track_id',
+        'visits_all_time',
+    ];
+
+    public function getIncrementing()
+    {
+        return false;
+    }
+
+    public function getKeyType()
+    {
+        return 'string';
+    }
+}

--- a/api/app/Modules/Library/Projectors/TrackStatisticsProjector.php
+++ b/api/app/Modules/Library/Projectors/TrackStatisticsProjector.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Modules\Library\Projectors;
+
+use App\Modules\Library\Events\Tracks\TrackViewed;
+use App\Modules\Library\Models\Visits\TrackStatistic;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Spatie\EventSourcing\EventHandlers\Projectors\Projector;
+
+class TrackStatisticsProjector extends Projector implements ShouldQueue
+{
+    public function onTrackViewed(TrackViewed $event): void
+    {
+        /** @var TrackStatistic $visits */
+        $visits = TrackStatistic::firstOrNew([
+            'track_id' => $event->id
+        ]);
+
+        $visits->visits_all_time = ($visits->visits_all_time ?? 0) + 1;
+
+        $visits->save();
+    }
+
+    public function resetState(): void
+    {
+        TrackStatistic::truncate();
+    }
+}

--- a/api/database/migrations/data/2020_09_03_041449_create_track_statistics_table.php
+++ b/api/database/migrations/data/2020_09_03_041449_create_track_statistics_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateTrackStatisticsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::connection('data')->create('track_statistics', function (Blueprint $table) {
+            $table->uuid('track_id')->primary();
+            $table->integer('visits_all_time');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::connection('data')->dropIfExists('track_statistics');
+    }
+}


### PR DESCRIPTION
I expect this to take the popular tracks endpoint down from `~14s` in production to `~0.1s`.