### PR TITLE
Increase session lifetime to 90 days. Currently at 2 hours.

### DIFF
--- a/api/config/session.php
+++ b/api/config/session.php
@@ -31,7 +31,7 @@ return [
     |
     */
 
-    'lifetime' => env('SESSION_LIFETIME', 120),
+    'lifetime' => env('SESSION_LIFETIME', 90*24*60), // 90 day session lifetime
 
     'expire_on_close' => false,
 


### PR DESCRIPTION
A user will not be logged out unless they have been inactive for 90 days.
This is not a security concern because, well, there's not much in the way
of sensitive data here. Convenience is more important.

Closes #483.