### PR TITLE
Use new volume for Meilisearch v0.25.0

### DIFF
--- a/k8s/base/deployments.yml
+++ b/k8s/base/deployments.yml
@@ -186,7 +186,7 @@ spec:
       volumes:
         - name: search-data
           persistentVolumeClaim:
-            claimName: search-volume-v0.24.0
+            claimName: search-volume-v0.25.0
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/k8s/base/volumes.yml
+++ b/k8s/base/volumes.yml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: search-volume-v0.24.0
+  name: search-volume-v0.25.0
 spec:
   accessModes:
     - ReadWriteOnce


### PR DESCRIPTION
Fixes this error:
```sh
$ kubectl logs search-6d9958f455-bn7zr -n stg
Error: Version file is missing or the previous MeiliSearch engine version was below 0.24.0. Use a dump to update MeiliSearch.
```