### PR TITLE
Use newer image for Meilisearch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,7 +99,7 @@ services:
     volumes:
       - redis:/data
   search:
-    image: getmeili/meilisearch:v0.25.0
+    image: getmeili/meilisearch:v0.25.2
     restart: unless-stopped
     tty: true
     ports:

--- a/k8s/base/deployments.yml
+++ b/k8s/base/deployments.yml
@@ -176,7 +176,7 @@ spec:
     spec:
       containers:
         - name: search
-          image: getmeili/meilisearch:v0.25.0
+          image: getmeili/meilisearch:v0.25.2
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 7700
@@ -186,7 +186,7 @@ spec:
       volumes:
         - name: search-data
           persistentVolumeClaim:
-            claimName: search-volume-v0.25.0
+            claimName: search-volume-v0.25.2
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/k8s/base/volumes.yml
+++ b/k8s/base/volumes.yml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: search-volume-v0.25.0
+  name: search-volume-v0.25.2
 spec:
   accessModes:
     - ReadWriteOnce


### PR DESCRIPTION
Use v0.25.2 instead of v0.25.0 to see if that helps solve the k8s deploy issue.