### PR TITLE
Update to latest PHP 8.1 image

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------------------
 # Test Image
 # ---------------------------------------------------------------------------
-FROM --platform=linux/amd64 szainmehdi/php:8.1-dev-20211203 as test
+FROM --platform=linux/amd64 szainmehdi/php:8.1-dev-20230802 as test
 
 WORKDIR /var/www/api
 ENV APP_ENV production
@@ -20,7 +20,7 @@ RUN composer run post-root-package-install && php artisan key:generate
 # ---------------------------------------------------------------------------
 # Build Image
 # ---------------------------------------------------------------------------
-FROM --platform=linux/amd64 szainmehdi/php:8.1-dev-20211203 as build
+FROM --platform=linux/amd64 szainmehdi/php:8.1-dev-20230802 as build
 
 WORKDIR /var/www/api
 ENV APP_ENV production
@@ -36,7 +36,7 @@ RUN composer install -n --no-dev --prefer-dist --no-scripts --no-autoloader \
 # ---------------------------------------------------------------------------
 # Production Image
 # ---------------------------------------------------------------------------
-FROM --platform=linux/amd64 szainmehdi/php:8.1-20211203 as production
+FROM --platform=linux/amd64 szainmehdi/php:8.1-20230802 as production
 
 WORKDIR /var/www/api
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -2,7 +2,7 @@ version: '3.9'
 
 services:
   api:
-    image: szainmehdi/php:8.1-dev-20211203
+    image: szainmehdi/php:8.1-dev-20230802
     working_dir: /var/www/api
     ports:
       - "9000:9000"
@@ -15,14 +15,14 @@ services:
     volumes:
       - ./api:/var/www/api:delegated
   queue:
-    image: szainmehdi/php:8.1-dev-20211203
+    image: szainmehdi/php:8.1-dev-20230802
     working_dir: /var/www/api
     environment:
       - APP_ENV=local
     volumes:
       - ./api:/var/www/api:delegated
   test:
-    image: szainmehdi/php:8.1-dev-20211203
+    image: szainmehdi/php:8.1-dev-20230802
     working_dir: /var/www/api
     volumes:
       - ./api:/var/www/api:delegated


### PR DESCRIPTION
Uses the latest PHP 8.1 docker images built using  https://github.com/szainmehdi/dockerfiles/commit/46c0b45166a31e2015ade31e96d1f0624d1328e9 and https://github.com/szainmehdi/dockerfiles/commit/565ea2d1fb0d0f07048653b38ee3e74d906a472e

```
/var/www/api # php -v
PHP 8.1.21 (cli) (built: Jul 10 2023 23:14:30) (NTS)
Copyright (c) The PHP Group
Zend Engine v4.1.21, Copyright (c) Zend Technologies
    with Zend OPcache v8.1.21, Copyright (c), by Zend Technologies
    with Xdebug v3.2.2, Copyright (c) 2002-2023, by Derick Rethans
```