### PR TITLE
Enable Sentry tracing and upgrade Sentry

### DIFF
--- a/api/composer.json
+++ b/api/composer.json
@@ -22,7 +22,7 @@
         "league/fractal": "^0.19.2",
         "meilisearch/meilisearch-php": "0.23.*",
         "myclabs/php-enum": "^1.7",
-        "sentry/sentry-laravel": "^2.10",
+        "sentry/sentry-laravel": "^3.7",
         "spatie/laravel-event-sourcing": "^6.0",
         "spatie/laravel-responsecache": "^7.1",
         "spatie/laravel-sluggable": "^3.0",

--- a/api/composer.lock
+++ b/api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e767c78aa7406f09e6b1c525438bd05c",
+    "content-hash": "0a817bfda4c8da41c3a1128c7dcd9875",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -5387,37 +5387,40 @@
         },
         {
             "name": "sentry/sentry-laravel",
-            "version": "2.14.2",
+            "version": "3.7.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/getsentry/sentry-laravel.git",
-                "reference": "4538ed31d77868dd3b6d72ad6e5e68b572beeb9f"
+                "reference": "2aee4ad217be8ef04ffcde6e9f7dd17af5a3b0bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/getsentry/sentry-laravel/zipball/4538ed31d77868dd3b6d72ad6e5e68b572beeb9f",
-                "reference": "4538ed31d77868dd3b6d72ad6e5e68b572beeb9f",
+                "url": "https://api.github.com/repos/getsentry/sentry-laravel/zipball/2aee4ad217be8ef04ffcde6e9f7dd17af5a3b0bf",
+                "reference": "2aee4ad217be8ef04ffcde6e9f7dd17af5a3b0bf",
                 "shasum": ""
             },
             "require": {
-                "illuminate/support": "5.0 - 5.8 | ^6.0 | ^7.0 | ^8.0 | ^9.0",
+                "illuminate/support": "^6.0 | ^7.0 | ^8.0 | ^9.0 | ^10.0",
                 "nyholm/psr7": "^1.0",
                 "php": "^7.2 | ^8.0",
-                "sentry/sdk": "^3.1",
-                "sentry/sentry": "^3.3",
+                "sentry/sdk": "^3.4",
+                "sentry/sentry": "^3.20.1",
                 "symfony/psr-http-message-bridge": "^1.0 | ^2.0"
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "^3.11",
-                "laravel/framework": "5.0 - 5.8 | ^6.0 | ^7.0 | ^8.0 | ^9.0",
+                "laravel/framework": "^6.0 | ^7.0 | ^8.0 | ^9.0 | ^10.0",
                 "mockery/mockery": "^1.3",
-                "orchestra/testbench": "3.1 - 3.8 | ^4.7 | ^5.1 | ^6.0 | ^7.0",
-                "phpunit/phpunit": "^5.7 | ^6.5 | ^7.5 | ^8.4 | ^9.3"
+                "orchestra/testbench": "^4.7 | ^5.1 | ^6.0 | ^7.0 | ^8.0",
+                "phpstan/phpstan": "^1.10",
+                "phpunit/phpunit": "^8.4 | ^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.x-dev",
+                    "dev-master": "3.x-dev",
+                    "dev-2.x": "2.x-dev",
+                    "dev-1.x": "1.x-dev",
                     "dev-0.x": "0.x-dev"
                 },
                 "laravel": {
@@ -5437,7 +5440,7 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "Apache-2.0"
+                "MIT"
             ],
             "authors": [
                 {
@@ -5459,7 +5462,7 @@
             ],
             "support": {
                 "issues": "https://github.com/getsentry/sentry-laravel/issues",
-                "source": "https://github.com/getsentry/sentry-laravel/tree/2.14.2"
+                "source": "https://github.com/getsentry/sentry-laravel/tree/3.7.3"
             },
             "funding": [
                 {
@@ -5471,7 +5474,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2022-10-13T09:21:29+00:00"
+            "time": "2023-08-03T10:10:23+00:00"
         },
         {
             "name": "spatie/better-types",

--- a/api/config/sentry.php
+++ b/api/config/sentry.php
@@ -1,24 +1,103 @@
 <?php
 
+/**
+ * Sentry Laravel SDK configuration file.
+ *
+ * @see https://docs.sentry.io/platforms/php/guides/laravel/configuration/options/
+ */
 return [
 
+    // @see https://docs.sentry.io/product/sentry-basics/dsn-explainer/
     'dsn' => env('SENTRY_LARAVEL_DSN', env('SENTRY_DSN')),
 
-    // capture release as git sha
-     'release' => env('GIT_SHA'),
+    // The release version of your application
+    // Example with dynamic git hash: trim(exec('git --git-dir ' . base_path('.git') . ' log --pretty="%h" -n1 HEAD'))
+    'release' => env('GIT_SHA'),
 
+    // When left empty or `null` the Laravel environment will be used (usually discovered from `APP_ENV` in your `.env`)
+    'environment' => null,
+
+    // @see: https://docs.sentry.io/platforms/php/guides/laravel/configuration/options/#sample-rate
+    'sample_rate' => (float)env('SENTRY_SAMPLE_RATE', 1.0),
+
+    // @see: https://docs.sentry.io/platforms/php/guides/laravel/configuration/options/#traces-sample-rate
+    'traces_sample_rate' => (float)env('SENTRY_TRACES_SAMPLE_RATE', 1.0),
+
+    // @see: https://docs.sentry.io/platforms/php/guides/laravel/configuration/options/#profiles-sample-rate
+    'profiles_sample_rate' => env('SENTRY_PROFILES_SAMPLE_RATE') === null
+        ? null
+        : (float)env(
+            'SENTRY_PROFILES_SAMPLE_RATE'
+        ),
+
+    // @see: https://docs.sentry.io/platforms/php/guides/laravel/configuration/options/#send-default-pii
+    'send_default_pii' => true,
+
+    // Breadcrumb specific configuration
     'breadcrumbs' => [
-        // Capture Laravel logs in breadcrumbs
+        // Capture Laravel logs as breadcrumbs
         'logs' => true,
 
-        // Capture SQL queries in breadcrumbs
+        // Capture Laravel cache events (hits, writes etc.) as breadcrumbs
+        'cache' => true,
+
+        // Capture Livewire components like routes as breadcrumbs
+        'livewire' => false,
+
+        // Capture SQL queries as breadcrumbs
         'sql_queries' => true,
 
-        // Capture bindings on SQL queries logged in breadcrumbs
+        // Capture SQL query bindings (parameters) in SQL query breadcrumbs
         'sql_bindings' => true,
 
-        // Capture queue job information in breadcrumbs
+        // Capture queue job information as breadcrumbs
         'queue_info' => true,
+
+        // Capture command information as breadcrumbs
+        'command_info' => true,
+
+        // Capture HTTP client request information as breadcrumbs
+        'http_client_requests' => true,
+    ],
+
+    // Performance monitoring specific configuration
+    'tracing' => [
+        // Trace queue jobs as their own transactions (this enables tracing for queue jobs)
+        'queue_job_transactions' => true,
+
+        // Capture queue jobs as spans when executed on the sync driver
+        'queue_jobs' => true,
+
+        // Capture SQL queries as spans
+        'sql_queries' => true,
+
+        // Capture where the SQL query originated from on the SQL query spans
+        'sql_origin' => true,
+
+        // Capture views rendered as spans
+        'views' => true,
+
+        // Capture Livewire components as spans
+        'livewire' => false,
+
+        // Capture HTTP client requests as spans
+        'http_client_requests' => true,
+
+        // Capture Redis operations as spans (this enables Redis events in Laravel)
+        'redis_commands' => true,
+
+        // Capture where the Redis command originated from on the Redis command spans
+        'redis_origin' => true,
+
+        // Enable tracing for requests without a matching route (404's)
+        'missing_routes' => false,
+
+        // Configures if the performance trace should continue after the response has been sent to the user until the application terminates
+        // This is required to capture any spans that are created after the response has been sent like queue jobs dispatched using `dispatch(...)->afterResponse()` for example
+        'continue_after_response' => true,
+
+        // Enable the tracing integrations supplied by Sentry (recommended)
+        'default_integrations' => true,
     ],
 
 ];


### PR DESCRIPTION
https://docs.sentry.io/platforms/php/guides/laravel/performance/

Upgrades `sentry/sentry-laravel` from `2.14.2` to [`3.7.3`](https://github.com/getsentry/sentry-laravel/releases/tag/3.7.3)