### PR TITLE
Enable Sentry for frontend using correct sentry DSN env variable

### DIFF
--- a/nuxt/nuxt.config.js
+++ b/nuxt/nuxt.config.js
@@ -289,7 +289,7 @@ export default {
    ** See https://github.com/nuxt-community/sentry-module
    */
   sentry: {
-    dsn: process.env.BUILD_SENTRY_DSN || '',
+    dsn: process.env.SENTRY_DSN || '',
     publishRelease: process.env.BUILD_SENTRY_PUBLISH_RELEASE || false,
     sourceMapStyle: 'hidden-source-map',
     config: {


### PR DESCRIPTION
In production:

```
➜  ~ kube logs -f web-58549658cc-5b5jn
yarn run v1.22.19
$ nuxt-ts start
ℹ Sentry reporting is disabled (no DSN has been provided)
ℹ Listening on: http://10.244.0.76:3000/
```