### PR TITLE
Make sure to use docker-compose.override.yml

### DIFF
--- a/dev
+++ b/dev
@@ -58,6 +58,11 @@ else
   COMPOSE="$COMPOSE -f docker-compose.dev.yml"
 fi
 
+if test -e "docker-compose.override.yml"; then
+  echo "> Overrides from docker-compose.override.yml applied."
+  COMPOSE="$COMPOSE -f docker-compose.override.yml"
+fi
+
 # If we pass any arguments...
 if [ $# -gt 0 ];then
     # If "art" is used, pass-thru to "artisan"


### PR DESCRIPTION
Docker appears to have changed default behavior, and `docker-compose.override.yml` is no longer respected automatically.

We should definitely upgrade and rework our docker-compose setup eventually but this gets us going again for now.