### PR TITLE
Fixed issue with RevisionTransformer createdAt

### DIFF
--- a/api/app/Modules/Audit/Http/Transformers/RevisionTransformer.php
+++ b/api/app/Modules/Audit/Http/Transformers/RevisionTransformer.php
@@ -39,7 +39,7 @@ class RevisionTransformer extends Transformer
             'previous' => $this->prepareSnapshot($revision->old_values, $revision->getEntityType()),
             'snapshot' => $this->prepareSnapshot($revision->new_values, $revision->getEntityType()),
             'meta' => $this->getMeta($revision),
-            'createdAt' => $revision->created_at,
+            'createdAt' => $this->dateTime($revision->created_at),
         ];
     }
 

--- a/api/app/Modules/Audit/Http/Transformers/RevisionTransformer.php
+++ b/api/app/Modules/Audit/Http/Transformers/RevisionTransformer.php
@@ -39,7 +39,7 @@ class RevisionTransformer extends Transformer
             'previous' => $this->prepareSnapshot($revision->old_values, $revision->getEntityType()),
             'snapshot' => $this->prepareSnapshot($revision->new_values, $revision->getEntityType()),
             'meta' => $this->getMeta($revision),
-            'createdAt' => $this->dateTime($revision->created_at),
+            'createdAt' => $revision->created_at,
         ];
     }
 

--- a/api/app/Modules/Audit/Models/Revision.php
+++ b/api/app/Modules/Audit/Models/Revision.php
@@ -42,10 +42,6 @@ class Revision extends Model
 
     public $timestamps = false;
 
-    protected $dates = [
-        'created_at',
-    ];
-
     protected $casts = [
         'old_values' => 'array',
         'new_values' => 'array',

--- a/api/app/Modules/Audit/Models/Revision.php
+++ b/api/app/Modules/Audit/Models/Revision.php
@@ -49,6 +49,7 @@ class Revision extends Model
     protected $casts = [
         'old_values' => 'array',
         'new_values' => 'array',
+        'created_at' => 'datetime'
     ];
 
     public function getChangeType(): ChangeType

--- a/api/app/Modules/Authentication/Models/PasswordResetToken.php
+++ b/api/app/Modules/Authentication/Models/PasswordResetToken.php
@@ -30,8 +30,8 @@ class PasswordResetToken extends Model
 
     public $timestamps = false;
 
-    protected $dates = [
-        'created_at',
+    protected $casts = [
+        'created_at' => 'datetime'
     ];
 
     protected $fillable = [

--- a/api/app/Modules/Library/Models/Visit.php
+++ b/api/app/Modules/Library/Models/Visit.php
@@ -22,7 +22,9 @@ class Visit extends Model
 {
     protected $fillable = ['visited_at', 'visitable_id', 'visitable_type'];
 
-    protected $dates = ['visited_at'];
+    protected $casts = [
+        'visited_at' => 'datetime'
+    ];
 
     public $timestamps = false;
 }


### PR DESCRIPTION
This fixes and closes issue #607 

As we are already using the $dates property on the model, there is no need to convert this to DateTime hence removed the conversion
I have tested this on my local and the Audit now appears with the correct info