### PR TITLE
Fixed search volume data mapping

### DIFF
--- a/k8s/base/deployments.yml
+++ b/k8s/base/deployments.yml
@@ -181,7 +181,7 @@ spec:
           ports:
             - containerPort: 7700
           volumeMounts:
-              - mountPath: /home/meili/data.ms
+              - mountPath: /meili_data
                 name: search-data
       volumes:
         - name: search-data


### PR DESCRIPTION
As per meilisearch documentation for V1.3.2 (which is the version we are currently using)
https://github.com/meilisearch/documentation/blob/v1.3/learn/getting_started/installation.mdx

The data should get mounted to `/meili_data` however we are currently mapping to folder `/home/meili/data.ms`
Due to this, whenever the container restarted, we lost our data
This should now fix this


We will have to delete the volume manually in case it contains invalid data, and then reindex the search post deployment