### PR TITLE
Add eager loading of includes to Track

### DIFF
--- a/api/app/Http/Controllers/TransformsResponses.php
+++ b/api/app/Http/Controllers/TransformsResponses.php
@@ -22,6 +22,11 @@ trait TransformsResponses
      */
     protected function respondWithItem($item, Transformer $transformer = null): JsonResponse
     {
+        // Eager load relationships before passing it through the transformer.
+        if (method_exists($item, 'loadIncludes')) {
+            $item->loadIncludes(request()->get('include'));
+        }
+
         $transformer = $transformer ?: $this->transformer;
         $resource = new FractalItem($item, $transformer);
         $rootScope = $this->getFractal()->createData($resource);

--- a/api/app/Modules/Core/Models/EagerLoadsRelations.php
+++ b/api/app/Modules/Core/Models/EagerLoadsRelations.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Modules\Core\Models;
+
+use Illuminate\Contracts\Database\Eloquent\Builder;
+
+/**
+ * @method static \Illuminate\Database\Eloquent\Builder|static withIncludes(string|null $includes)
+ */
+trait EagerLoadsRelations
+{
+    /**
+     * @return array<string, class-string>
+     */
+    abstract public function getEagerLoadableRelations(): array;
+
+    public function scopeWithIncludes(Builder $query, string|null $includes): Builder
+    {
+        if ($includes === null) {
+            return $query;
+        }
+
+        return $query->with($this->getEagerLoadableRelationsFromIncludes($includes));
+    }
+
+    public function loadIncludes(string|null $includes): void
+    {
+        if ($includes === null) {
+            return;
+        }
+
+        $this->loadMissing($this->getEagerLoadableRelationsFromIncludes($includes));
+    }
+
+    public function getEagerLoadableRelationsFromIncludes(string $includes): array
+    {
+        $relations = explode(',', $includes);
+
+        return array_filter($relations, function (string $include) {
+            return $this->isEagerLoadable($this, $include);
+        });
+    }
+
+    private function isEagerLoadable(object $model, string $include): bool {
+        if (!method_exists($model, 'getEagerLoadableRelations')) {
+            return false;
+        }
+
+        $parts = explode('.', $include);
+        if (count($parts) === 0) {
+            return false;
+        }
+
+        $related = $parts[0];
+        $definition = $model->getEagerLoadableRelations()[$related] ?? null;
+
+        if ($definition === null) {
+            return false;
+        }
+
+        if (count($parts) === 1) {
+            return true;
+        }
+
+        return $this->isEagerLoadable(new $definition(), implode('.', array_slice($parts, 1)));
+    }
+}

--- a/api/app/Modules/Core/Models/EagerLoadsRelations.php
+++ b/api/app/Modules/Core/Models/EagerLoadsRelations.php
@@ -47,9 +47,6 @@ trait EagerLoadsRelations
         }
 
         $parts = explode('.', $include);
-        if (count($parts) === 0) {
-            return false;
-        }
 
         $related = $parts[0];
         $definition = $model->getEagerLoadableRelations()[$related] ?? null;

--- a/api/app/Modules/Core/Models/EagerLoadsRelations.php
+++ b/api/app/Modules/Core/Models/EagerLoadsRelations.php
@@ -14,7 +14,7 @@ trait EagerLoadsRelations
      */
     abstract public function getEagerLoadableRelations(): array;
 
-    public function scopeWithIncludes(Builder $query, string|null $includes): Builder
+    public function scopeWithIncludes(Builder $query, string|null $includes)
     {
         if ($includes === null) {
             return $query;

--- a/api/app/Modules/Library/Http/Controllers/TracksController.php
+++ b/api/app/Modules/Library/Http/Controllers/TracksController.php
@@ -27,6 +27,7 @@ class TracksController extends Controller
     {
         $tracks = $album->tracks()
             ->orderBy('title')
+            ->withIncludes($request->get('include'))
             ->paginate(PaginationState::fromRequest($request)->getLimit());
 
         return $this->respondWithPaginator($tracks);

--- a/api/app/Modules/Library/Models/Album.php
+++ b/api/app/Modules/Library/Models/Album.php
@@ -7,6 +7,7 @@ namespace App\Modules\Library\Models;
 use App\Modules\Audit\Models\HasRevisions;
 use App\Modules\Audit\Revisionable\Revisionable;
 use App\Modules\Core\Contracts\TimestampedEntity;
+use App\Modules\Core\Models\EagerLoadsRelations;
 use App\Modules\Core\Models\HasTimestamps;
 use App\Modules\Core\Models\HasUuid;
 use App\Modules\Core\Models\UsesDataConnection;
@@ -49,8 +50,16 @@ class Album extends Model implements TimestampedEntity, Revisionable
     use HasRevisions;
     use UsesDataConnection;
     use Searchable;
+    use EagerLoadsRelations;
 
     protected $guarded = [];
+
+    public function getEagerLoadableRelations(): array
+    {
+        return [
+            'tracks' => Track::class,
+        ];
+    }
 
     public function getArtworkUrl(): ?string
     {

--- a/api/app/Modules/Library/Models/Track.php
+++ b/api/app/Modules/Library/Models/Track.php
@@ -7,6 +7,7 @@ namespace App\Modules\Library\Models;
 use App\Modules\Audit\Models\HasRevisions;
 use App\Modules\Audit\Revisionable\Revisionable;
 use App\Modules\Core\Contracts\TimestampedEntity;
+use App\Modules\Core\Models\EagerLoadsRelations;
 use App\Modules\Core\Models\HasTimestamps;
 use App\Modules\Core\Models\HasUuid;
 use App\Modules\Core\Models\UsesDataConnection;
@@ -73,12 +74,21 @@ class Track extends Model implements TimestampedEntity, Revisionable
     use UsesDataConnection;
     use Visitable;
     use Searchable;
+    use EagerLoadsRelations;
 
     protected $guarded = [];
 
     protected $casts = [
         'lyrics' => Casts\Lyrics::class,
     ];
+
+    public function getEagerLoadableRelations(): array
+    {
+        return [
+            'reciter' => Reciter::class,
+            'album' => Album::class,
+        ];
+    }
 
     public static function create(Album $album, string $title): self
     {

--- a/api/tests/Unit/Modules/Core/Models/EagerLoadsRelationsTest.php
+++ b/api/tests/Unit/Modules/Core/Models/EagerLoadsRelationsTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Unit\Modules\Core\Models;
+
+use App\Modules\Library\Models\Track;
+use Tests\TestCase;
+
+class EagerLoadsRelationsTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_returns_only_defined_eager_loadable_relations_recursively()
+    {
+        $track = new Track();
+        $includes = 'reciter,lyrics,media,album,album.tracks,album.tracks.reciter,album.tracks.lyrics,album.tracks.media,album.tracks.album,album.tracks.related';
+
+        $this->assertEqualsCanonicalizing([
+            'reciter',
+            'album',
+            'album.tracks',
+            'album.tracks.reciter',
+            'album.tracks.album',
+        ], $track->getEagerLoadableRelationsFromIncludes($includes));
+    }
+}


### PR DESCRIPTION
To help deal with the N+1 error notifications and optimize performance, I added a trait that helps eager load relations for models before sending it through the transformer. This should hopefully help a lot.