### PR TITLE
Fix failing Dusk tests

### DIFF
--- a/api/tests/Browser/LibraryHomePageTest.php
+++ b/api/tests/Browser/LibraryHomePageTest.php
@@ -22,11 +22,10 @@ class LibraryHomePageTest extends DuskTestCase
         $this->browse(function (Browser $browser) {
             $contributor = User::findByEmail('contributor@nawhas.test');
 
+            $this->loginViaUi($browser, $contributor);
+
             $libraryHomePage = new LibraryHome();
-            $browser->loginAs($contributor)
-                ->assertAuthenticatedAs($contributor)
-                ->visit($libraryHomePage)
-                ->logout();
+            $browser->visit($libraryHomePage);
         });
     }
 }

--- a/api/tests/Browser/TrackPageTest.php
+++ b/api/tests/Browser/TrackPageTest.php
@@ -133,7 +133,7 @@ class TrackPageTest extends DuskTestCase
         $track = $this->getTrackFactory()->create($album, [
             'title' => 'Test Track',
             'audio' => 'test-audio.mp3',
-            'video' => 'test-video.mp4',
+            'video' => 'https://www.youtube.com/watch?v=ZQ3lvKU3ukg',
         ]);
 
         $this->browse(function ($browser) use ($reciter, $album, $track) {

--- a/api/tests/DuskTestCase.php
+++ b/api/tests/DuskTestCase.php
@@ -90,4 +90,19 @@ abstract class DuskTestCase extends BaseTestCase
             User::create(Role::Moderator, 'Moderator One', 'moderator@nawhas.test', 'secret');
         }
     }
+
+    protected function loginViaUi(\Laravel\Dusk\Browser $browser, User $user, string $password = 'secret'): void
+    {
+        $browser->visit('/')
+            ->waitFor('@user-menu__avatar', seconds: 10)
+            ->click('@user-menu__avatar')
+            ->waitFor('@user-menu__login-button')
+            ->click('@user-menu__login-button')
+            ->waitFor('.auth-dialog')
+            ->type('.auth-dialog input[type=email]', $user->email)
+            ->type('.auth-dialog input[type=password]', $password)
+            ->press('.auth-dialog button[type=submit]')
+            ->waitUntilVue('authenticated', "true", '@user-menu')
+            ->pause(1000);
+    }
 }

--- a/api/tests/Factories/TrackFactory.php
+++ b/api/tests/Factories/TrackFactory.php
@@ -38,6 +38,10 @@ class TrackFactory extends Factory
             $track->changeAudio($audio);
         }
 
+        if ($values->has('video')) {
+            $track->changeVideo($values->get('video'));
+        }
+
         return $track;
     }
 }


### PR DESCRIPTION
Fixes the failing Dusk tests on the `more-dusk` branch.

- `LibraryHomePageTest`: The test was failing because `loginAs` hits `/_dusk/login` using the base URL, which is the frontend. This returned a 404, so the user was never logged in. I fixed this by adding a `loginViaUi` helper to `DuskTestCase` that uses the UI to log in instead.
- `TrackPageTest`: The test was failing because it was waiting for the video player to appear, but the track was created with `test-video.mp4`. The frontend uses `getYouTubeID` to parse the video URL, which returns null for invalid URLs, causing the video player to not render. I changed the video URL to a valid YouTube URL.

Made with [Cursor](https://cursor.com)