### PR TITLE
Expand Dusk assertions beyond basic navigation

### DIFF
--- a/api/tests/Browser/AlbumPageTest.php
+++ b/api/tests/Browser/AlbumPageTest.php
@@ -68,7 +68,13 @@ class AlbumPageTest extends DuskTestCase
 
             $browser->visit($page)
                 ->assertPlayButtonVisible()
+                ->clickPlayAlbumButton()
+                // The global player should show up, but we'll test that elsewhere.
+                // Test the add to queue button interaction
                 ->assertAddToQueueButtonVisible()
+                ->clickAddToQueueButton()
+                ->assertAddedToQueueButtonVisible()
+                ->assertAddedToQueueSnackbarVisible()
                 ->assertTrackCount(1);
         });
     }

--- a/api/tests/Browser/HomePageTest.php
+++ b/api/tests/Browser/HomePageTest.php
@@ -17,7 +17,12 @@ class HomePageTest extends DuskTestCase
     {
         $this->browse(function (Browser $browser) {
             $browser->visit('/')
-                ->on(new Home);
+                ->on(new Home)
+                // Test interaction: search input focuses and shows results container
+                ->click('input[placeholder="Search Nawhas.com"]')
+                ->type('input[placeholder="Search Nawhas.com"]', 'Nadeem')
+                ->waitForText('Showing results for “Nadeem”')
+                ->assertSee('Showing results for “Nadeem”');
         });
     }
 }

--- a/api/tests/Browser/LibraryPageTest.php
+++ b/api/tests/Browser/LibraryPageTest.php
@@ -20,6 +20,11 @@ class LibraryPageTest extends DuskTestCase
             $libraryPage = new Library();
             $browser->logout()->visit($libraryPage);
             $libraryPage->verifyPageWhenUnauthenticated($browser);
+            
+            // Test interaction: clicking Get Started should open auth dialog
+            $libraryPage->clickGetStartedButton($browser);
+            $browser->waitFor('.auth-dialog')
+                ->assertSeeIn('.auth-dialog', 'Sign Up');
         });
     }
 }

--- a/api/tests/Browser/LibraryTracksTest.php
+++ b/api/tests/Browser/LibraryTracksTest.php
@@ -17,12 +17,23 @@ class LibraryTracksTest extends DuskTestCase
     public function test_library_tracks_page_renders_for_authenticated_user(): void
     {
         $user = $this->getUserFactory()->contributor(['password' => 'secret']);
+        $reciter = $this->getReciterFactory()->create();
+        $album = $this->getAlbumFactory()->create($reciter);
+        $track = $this->getTrackFactory()->create($album);
 
-        $this->browse(function (Browser $browser) use ($user) {
+        // Add track to user's saved tracks
+        $user->savedTracks()->attach($track->id, ['created_at' => now()]);
+
+        $this->browse(function (Browser $browser) use ($user, $track) {
             $this->loginViaUi($browser, $user, 'secret');
             $browser->visit(new LibraryTracks())
                 ->waitFor('@heading', 10)
-                ->assertSeeIn('@heading', 'Saved Nawhas');
+                ->assertSeeIn('@heading', 'Saved Nawhas')
+                // Test interaction: track is visible and clicking it navigates to track page
+                ->waitForText($track->title)
+                ->clickLink($track->title)
+                ->waitForLocation("/reciters/{$track->reciter->slug}/albums/{$track->album->year}/tracks/{$track->slug}")
+                ->assertPathIs("/reciters/{$track->reciter->slug}/albums/{$track->album->year}/tracks/{$track->slug}");
         });
     }
 }

--- a/api/tests/Browser/Pages/Album.php
+++ b/api/tests/Browser/Pages/Album.php
@@ -94,7 +94,7 @@ class Album extends Page
     {
         $browser->waitFor('@playAlbumButton')
             ->assertVisible('@playAlbumButton')
-            ->assertSee('PLAY ALBUM');
+            ->waitForTextIn('@playAlbumButton', 'PLAY ALBUM');
     }
 
     /**
@@ -107,7 +107,7 @@ class Album extends Page
     {
         $browser->waitFor('@addToQueueButton')
             ->assertVisible('@addToQueueButton')
-            ->assertSee('ADD TO QUEUE');
+            ->waitForTextIn('@addToQueueButton', 'ADD TO QUEUE');
     }
 
     /**
@@ -120,7 +120,7 @@ class Album extends Page
     {
         $browser->waitFor('@addedToQueueButton')
             ->assertVisible('@addedToQueueButton')
-            ->assertSee('ADDED TO QUEUE');
+            ->waitForTextIn('@addedToQueueButton', 'ADDED TO QUEUE');
     }
 
     /**

--- a/api/tests/Browser/Pages/Album.php
+++ b/api/tests/Browser/Pages/Album.php
@@ -111,6 +111,31 @@ class Album extends Page
     }
 
     /**
+     * Assert that the album page shows the added to queue button.
+     *
+     * @param Browser $browser
+     * @return void
+     */
+    public function assertAddedToQueueButtonVisible(Browser $browser): void
+    {
+        $browser->waitFor('@addedToQueueButton')
+            ->assertVisible('@addedToQueueButton')
+            ->assertSee('ADDED TO QUEUE');
+    }
+
+    /**
+     * Assert that the added to queue snackbar is visible.
+     *
+     * @param Browser $browser
+     * @return void
+     */
+    public function assertAddedToQueueSnackbarVisible(Browser $browser): void
+    {
+        $browser->waitFor('@addedToQueueSnackbar')
+            ->assertVisible('@addedToQueueSnackbar');
+    }
+
+    /**
      * Click the play album button.
      *
      * @param Browser $browser
@@ -188,6 +213,8 @@ class Album extends Page
             '@trackList' => '[dusk="track-list"]',
             '@playAlbumButton' => '[dusk="play-album-button"]',
             '@addToQueueButton' => '[dusk="add-to-queue-button"]',
+            '@addedToQueueButton' => '[dusk="added-to-queue-button"]',
+            '@addedToQueueSnackbar' => '[dusk="added-to-queue-snackbar"]',
             '@trackItems' => '[dusk="track-list"] .v-list-item',
         ];
     }

--- a/api/tests/Browser/Pages/Library.php
+++ b/api/tests/Browser/Pages/Library.php
@@ -57,4 +57,16 @@ class Library extends Page
         $browser->waitFor('@libraryButton')->assertButtonEnabled('@libraryButton');
         $browser->waitFor('@libraryButtonText')->assertSeeIn('@libraryButtonText', 'GET STARTED');
     }
+
+    /**
+     * Click the get started button.
+     *
+     * @param Browser $browser
+     * @return void
+     */
+    public function clickGetStartedButton(Browser $browser): void
+    {
+        $browser->waitFor('@libraryButton')
+            ->click('@libraryButton');
+    }
 }

--- a/api/tests/Browser/Pages/ReciterProfile.php
+++ b/api/tests/Browser/Pages/ReciterProfile.php
@@ -39,6 +39,7 @@ class ReciterProfile extends Page
         return [
             '@title' => '[dusk="reciter-profile__title"]',
             '@albums-section' => '#albums-section',
+            '@album-title-link' => '[dusk="album-title-link"]',
         ];
     }
 }

--- a/api/tests/Browser/Pages/Track.php
+++ b/api/tests/Browser/Pages/Track.php
@@ -119,7 +119,7 @@ class Track extends Page
     {
         $browser->waitFor('@playButton')
             ->assertVisible('@playButton')
-            ->assertSee('PLAY');
+            ->waitForTextIn('@playButton', 'PLAY');
     }
 
     /**
@@ -132,7 +132,7 @@ class Track extends Page
     {
         $browser->waitFor('@stopButton')
             ->assertVisible('@stopButton')
-            ->assertSee('STOP');
+            ->waitForTextIn('@stopButton', 'STOP');
     }
 
     /**
@@ -145,7 +145,7 @@ class Track extends Page
     {
         $browser->waitFor('@addToQueueButton')
             ->assertVisible('@addToQueueButton')
-            ->assertSee('ADD TO QUEUE');
+            ->waitForTextIn('@addToQueueButton', 'ADD TO QUEUE');
     }
 
     /**
@@ -158,7 +158,7 @@ class Track extends Page
     {
         $browser->waitFor('@addedToQueueButton')
             ->assertVisible('@addedToQueueButton')
-            ->assertSee('ADDED TO QUEUE');
+            ->waitForTextIn('@addedToQueueButton', 'ADDED TO QUEUE');
     }
 
     /**

--- a/api/tests/Browser/Pages/Track.php
+++ b/api/tests/Browser/Pages/Track.php
@@ -123,6 +123,19 @@ class Track extends Page
     }
 
     /**
+     * Assert that the stop button is visible.
+     *
+     * @param Browser $browser
+     * @return void
+     */
+    public function assertStopButtonVisible(Browser $browser): void
+    {
+        $browser->waitFor('@stopButton')
+            ->assertVisible('@stopButton')
+            ->assertSee('STOP');
+    }
+
+    /**
      * Assert that the add to queue button is visible.
      *
      * @param Browser $browser
@@ -136,6 +149,31 @@ class Track extends Page
     }
 
     /**
+     * Assert that the added to queue button is visible.
+     *
+     * @param Browser $browser
+     * @return void
+     */
+    public function assertAddedToQueueButtonVisible(Browser $browser): void
+    {
+        $browser->waitFor('@addedToQueueButton')
+            ->assertVisible('@addedToQueueButton')
+            ->assertSee('ADDED TO QUEUE');
+    }
+
+    /**
+     * Assert that the added to queue snackbar is visible.
+     *
+     * @param Browser $browser
+     * @return void
+     */
+    public function assertAddedToQueueSnackbarVisible(Browser $browser): void
+    {
+        $browser->waitFor('@addedToQueueSnackbar')
+            ->assertVisible('@addedToQueueSnackbar');
+    }
+
+    /**
      * Click the play button.
      *
      * @param Browser $browser
@@ -145,6 +183,18 @@ class Track extends Page
     {
         $browser->waitFor('@playButton')
             ->click('@playButton');
+    }
+
+    /**
+     * Click the stop button.
+     *
+     * @param Browser $browser
+     * @return void
+     */
+    public function clickStopButton(Browser $browser): void
+    {
+        $browser->waitFor('@stopButton')
+            ->click('@stopButton');
     }
 
     /**

--- a/api/tests/Browser/ReciterProfileTest.php
+++ b/api/tests/Browser/ReciterProfileTest.php
@@ -35,7 +35,11 @@ class ReciterProfileTest extends DuskTestCase
                 ->assertSeeIn('@title', $reciter->name)
                 ->assertSee('Top Nawhas')
                 ->assertSee($album->title)
-                ->assertSee($album->year);
+                ->assertSee($album->year)
+                // Test interaction: click album link and verify navigation
+                ->click('@album-title-link')
+                ->waitForLocation("/reciters/{$reciter->slug}/albums/{$album->year}")
+                ->assertPathIs("/reciters/{$reciter->slug}/albums/{$album->year}");
         });
     }
 }

--- a/api/tests/Browser/TrackPageTest.php
+++ b/api/tests/Browser/TrackPageTest.php
@@ -75,8 +75,9 @@ class TrackPageTest extends DuskTestCase
             $browser->visit($page)
                 ->assertPlayButtonVisible()
                 ->clickPlayButton()
-                // Add assertions for player state if needed
-                ->assertSee('STOP');
+                ->assertStopButtonVisible()
+                ->clickStopButton()
+                ->assertPlayButtonVisible();
         });
     }
 
@@ -108,8 +109,8 @@ class TrackPageTest extends DuskTestCase
             $browser->visit($page)
                 ->assertAddToQueueButtonVisible()
                 ->clickAddToQueueButton()
-                // Add assertions for queue state if needed
-                ->assertSee('ADDED TO QUEUE');
+                ->assertAddedToQueueButtonVisible()
+                ->assertAddedToQueueSnackbarVisible();
         });
     }
 

--- a/nuxt/components/albums/Album.vue
+++ b/nuxt/components/albums/Album.vue
@@ -10,7 +10,7 @@
         <lazy-image ref="artwork" crossorigin :src="image" :alt="album.title" />
       </v-avatar>
       <div class="album__details" :style="{ color: textColor }">
-        <nuxt-link :to="link" class="album__title">
+        <nuxt-link :to="link" class="album__title" dusk="album-title-link">
           <h5>{{ album.title }}</h5>
         </nuxt-link>
         <h6 class="album__release-date">

--- a/nuxt/pages/AlbumPage.vue
+++ b/nuxt/pages/AlbumPage.vue
@@ -77,6 +77,7 @@
                 v-if="addedToQueueSnackbar"
                 text
                 :color="textColor"
+                dusk="added-to-queue-button"
               >
                 <v-icon color="green" left>
                   done
@@ -101,7 +102,7 @@
       </div>
       <track-list :tracks="tracks" numbered />
     </v-container>
-    <v-snackbar v-model="addedToQueueSnackbar" right>
+    <v-snackbar v-model="addedToQueueSnackbar" right dusk="added-to-queue-snackbar">
       <v-icon color="white">
         playlist_add_check
       </v-icon>


### PR DESCRIPTION
Follow-up for NAW-42: expanded Dusk behavioral assertions and selectors.

Made with [Cursor](https://cursor.com)