### PR TITLE
Add responsive viewport Dusk coverage for critical pages

### DIFF
--- a/api/tests/Browser/ResponsiveViewportCoverageTest.php
+++ b/api/tests/Browser/ResponsiveViewportCoverageTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Browser;
+
+use Laravel\Dusk\Browser;
+use Tests\DuskTestCase;
+use Throwable;
+
+class ResponsiveViewportCoverageTest extends DuskTestCase
+{
+    /**
+     * @throws Throwable
+     */
+    public function test_critical_pages_render_across_responsive_viewports(): void
+    {
+        $viewports = [
+            'desktop' => [1440, 900],
+            'tablet' => [1024, 768],
+            'mobile' => [375, 812],
+        ];
+
+        $criticalPages = [
+            '/' => 'Trending This Month',
+            '/library' => 'Welcome to your library',
+            '/about' => 'The Journey',
+        ];
+
+        $this->browse(function (Browser $browser) use ($viewports, $criticalPages) {
+            foreach ($viewports as $label => [$width, $height]) {
+                $browser->resize($width, $height);
+
+                foreach ($criticalPages as $path => $expectedText) {
+                    $browser->visit($path)
+                        ->waitForText($expectedText, 10)
+                        ->assertSee($expectedText);
+
+                    $hasHorizontalOverflow = (bool) $browser->script(
+                        'return document.documentElement.scrollWidth > (document.documentElement.clientWidth + 1);'
+                    )[0];
+
+                    $this->assertFalse(
+                        $hasHorizontalOverflow,
+                        sprintf('Detected horizontal overflow on %s viewport for %s', $label, $path)
+                    );
+
+                }
+            }
+        });
+    }
+}

--- a/api/tests/Browser/ResponsiveViewportCoverageTest.php
+++ b/api/tests/Browser/ResponsiveViewportCoverageTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Browser;
 
+use App\Modules\Lyrics\Documents\Format;
 use Laravel\Dusk\Browser;
 use Tests\DuskTestCase;
 use Throwable;
@@ -13,38 +14,96 @@ class ResponsiveViewportCoverageTest extends DuskTestCase
      */
     public function test_critical_pages_render_across_responsive_viewports(): void
     {
+        $contributor = $this->getUserFactory()->contributor(['password' => 'secret']);
+        $moderator = $this->getUserFactory()->moderator(['password' => 'secret']);
+
+        $reciter = $this->getReciterFactory()->create();
+        $album = $this->getAlbumFactory()->create($reciter, [
+            'year' => '2024',
+        ]);
+        $track = $this->getTrackFactory()->create($album, [
+            'title' => 'Responsive Coverage Track',
+            'audio' => 'responsive-coverage-track.mp3',
+        ]);
+
+        $draftLyrics = $this->getDraftLyricsFactory()->create($track, [
+            'document' => $this->getDraftLyricsFactory()->generateDocument(Format::PlainText),
+        ]);
+        $this->getDraftLyricsFactory()->approve($draftLyrics);
+        $track->refresh();
+
+        $contributor->savedTracks()->attach($track->id, ['created_at' => now()]);
+
         $viewports = [
             'desktop' => [1440, 900],
             'tablet' => [1024, 768],
             'mobile' => [375, 812],
         ];
 
-        $criticalPages = [
+        $publicPages = [
             '/' => 'Trending This Month',
             '/library' => 'Welcome to your library',
             '/about' => 'The Journey',
+            '/reciters' => 'Reciters',
+            "/reciters/{$reciter->slug}" => $reciter->name,
+            "/reciters/{$reciter->slug}/albums/{$album->year}" => $album->title,
+            "/reciters/{$reciter->slug}/albums/{$album->year}/tracks/{$track->slug}" => $track->title,
+            "/print/{$reciter->slug}/{$album->year}/{$track->slug}" => $track->title,
         ];
 
-        $this->browse(function (Browser $browser) use ($viewports, $criticalPages) {
+        $this->browse(function (Browser $browser) use ($viewports, $publicPages, $contributor, $moderator, $track) {
             foreach ($viewports as $label => [$width, $height]) {
                 $browser->resize($width, $height);
 
-                foreach ($criticalPages as $path => $expectedText) {
+                foreach ($publicPages as $path => $expectedText) {
                     $browser->visit($path)
                         ->waitForText($expectedText, 10)
                         ->assertSee($expectedText);
 
-                    $hasHorizontalOverflow = (bool) $browser->script(
-                        'return document.documentElement.scrollWidth > (document.documentElement.clientWidth + 1);'
-                    )[0];
-
-                    $this->assertFalse(
-                        $hasHorizontalOverflow,
-                        sprintf('Detected horizontal overflow on %s viewport for %s', $label, $path)
-                    );
-
+                    $this->assertNoHorizontalOverflow($browser, $label, $path);
                 }
+
+                $browser->logout();
+                $this->loginViaUi($browser, $contributor, 'secret');
+
+                $browser->visit('/library/home')
+                    ->waitForText('My Library', 10)
+                    ->assertSee('My Library');
+                $this->assertNoHorizontalOverflow($browser, $label, '/library/home');
+
+                $browser->visit('/library/tracks')
+                    ->waitForText('Saved Nawhas', 10)
+                    ->assertSee('Saved Nawhas')
+                    ->assertSee($track->title);
+                $this->assertNoHorizontalOverflow($browser, $label, '/library/tracks');
+
+                $browser->logout();
+                $this->loginViaUi($browser, $moderator, 'secret');
+
+                $browser->visit('/moderator/drafts/lyrics')
+                    ->waitForText('Draft Lyrics', 10)
+                    ->assertSee('Draft Lyrics');
+                $this->assertNoHorizontalOverflow($browser, $label, '/moderator/drafts/lyrics');
+
+                $browser->visit('/moderator/revisions')
+                    ->waitForText('Revision History', 10)
+                    ->assertSee('Revision History');
+                $this->assertNoHorizontalOverflow($browser, $label, '/moderator/revisions');
+
+                $browser->logout();
             }
         });
+    }
+
+    private function assertNoHorizontalOverflow(Browser $browser, string $viewportLabel, string $path): void
+    {
+        $hasHorizontalOverflow = (bool) $browser->script(
+            'return document.documentElement.scrollWidth > (document.documentElement.clientWidth + 1);'
+        )[0];
+
+        $this->assertFalse(
+            $hasHorizontalOverflow,
+            sprintf('Detected horizontal overflow on %s viewport for %s', $viewportLabel, $path)
+        );
     }
 }

--- a/api/tests/Browser/ResponsiveViewportCoverageTest.php
+++ b/api/tests/Browser/ResponsiveViewportCoverageTest.php
@@ -67,8 +67,8 @@ class ResponsiveViewportCoverageTest extends DuskTestCase
                 $this->loginViaUi($browser, $contributor, 'secret');
 
                 $browser->visit('/library/home')
-                    ->waitForText('My Library', 10)
-                    ->assertSee('My Library');
+                    ->waitForText('Recently Saved Nawhas', 10)
+                    ->assertSee('Recently Saved Nawhas');
                 $this->assertNoHorizontalOverflow($browser, $label, '/library/home');
 
                 $browser->visit('/library/tracks')
@@ -76,6 +76,13 @@ class ResponsiveViewportCoverageTest extends DuskTestCase
                     ->assertSee('Saved Nawhas')
                     ->assertSee($track->title);
                 $this->assertNoHorizontalOverflow($browser, $label, '/library/tracks');
+
+                $trackPath = "/reciters/{$track->reciter->slug}/albums/{$track->album->year}/tracks/{$track->slug}";
+                $browser->visit($trackPath)
+                    ->waitForText($track->title, 10)
+                    ->assertPresent('.bar__actions--overflow [dusk="edit-draft-lyrics-button"]')
+                    ->assertPresent('[dusk="lyrics-card"]');
+                $this->assertNoHorizontalOverflow($browser, $label, $trackPath);
 
                 $browser->logout();
                 $this->loginViaUi($browser, $moderator, 'secret');

--- a/api/tests/Browser/ResponsiveViewportCoverageTest.php
+++ b/api/tests/Browser/ResponsiveViewportCoverageTest.php
@@ -4,9 +4,9 @@ namespace Tests\Browser;
 
 use App\Modules\Lyrics\Documents\Format;
 use App\Modules\Authentication\Models\User;
-use App\Modules\Lyrics\Models\Track;
-use App\Modules\Albums\Models\Album;
-use App\Modules\Reciters\Models\Reciter;
+use App\Modules\Library\Models\Album;
+use App\Modules\Library\Models\Reciter;
+use App\Modules\Library\Models\Track;
 use Laravel\Dusk\Browser;
 use Tests\DuskTestCase;
 use Throwable;
@@ -68,9 +68,11 @@ class ResponsiveViewportCoverageTest extends DuskTestCase
         $fixtures = $this->createFixtures();
         $path = "/reciters/{$fixtures['reciter']->slug}/albums/{$fixtures['album']->year}/tracks/{$fixtures['track']->slug}";
         $this->browse(function (Browser $browser) use ($path, $fixtures) {
+            $browser->logout();
+            $this->loginViaUi($browser, $fixtures['contributor'], 'secret');
+
             foreach (self::VIEWPORTS as $label => [$width, $height]) {
                 $browser->resize($width, $height)
-                    ->loginAs($fixtures['contributor'])
                     ->visit($path)
                     ->waitForText($fixtures['track']->title, 10)
                     ->assertPresent('.bar__actions--overflow [dusk="edit-draft-lyrics-button"]')
@@ -96,9 +98,11 @@ class ResponsiveViewportCoverageTest extends DuskTestCase
     {
         $fixtures = $this->createFixtures();
         $this->browse(function (Browser $browser) use ($fixtures) {
+            $browser->logout();
+            $this->loginViaUi($browser, $fixtures['contributor'], 'secret');
+
             foreach (self::VIEWPORTS as $label => [$width, $height]) {
                 $browser->resize($width, $height)
-                    ->loginAs($fixtures['contributor'])
                     ->visit('/library/home')
                     ->waitForText('Recently Saved Nawhas', 10)
                     ->assertSee('Recently Saved Nawhas');
@@ -113,9 +117,11 @@ class ResponsiveViewportCoverageTest extends DuskTestCase
     {
         $fixtures = $this->createFixtures();
         $this->browse(function (Browser $browser) use ($fixtures) {
+            $browser->logout();
+            $this->loginViaUi($browser, $fixtures['contributor'], 'secret');
+
             foreach (self::VIEWPORTS as $label => [$width, $height]) {
                 $browser->resize($width, $height)
-                    ->loginAs($fixtures['contributor'])
                     ->visit('/library/tracks')
                     ->waitForText('Saved Nawhas', 10)
                     ->assertSee('Saved Nawhas')
@@ -131,9 +137,11 @@ class ResponsiveViewportCoverageTest extends DuskTestCase
     {
         $fixtures = $this->createFixtures();
         $this->browse(function (Browser $browser) use ($fixtures) {
+            $browser->logout();
+            $this->loginViaUi($browser, $fixtures['moderator'], 'secret');
+
             foreach (self::VIEWPORTS as $label => [$width, $height]) {
                 $browser->resize($width, $height)
-                    ->loginAs($fixtures['moderator'])
                     ->visit('/moderator/drafts/lyrics')
                     ->waitForText('Draft Lyrics', 10)
                     ->assertSee('Draft Lyrics');
@@ -148,9 +156,11 @@ class ResponsiveViewportCoverageTest extends DuskTestCase
     {
         $fixtures = $this->createFixtures();
         $this->browse(function (Browser $browser) use ($fixtures) {
+            $browser->logout();
+            $this->loginViaUi($browser, $fixtures['moderator'], 'secret');
+
             foreach (self::VIEWPORTS as $label => [$width, $height]) {
                 $browser->resize($width, $height)
-                    ->loginAs($fixtures['moderator'])
                     ->visit('/moderator/revisions')
                     ->waitForText('Revision History', 10)
                     ->assertSee('Revision History');

--- a/api/tests/Browser/ResponsiveViewportCoverageTest.php
+++ b/api/tests/Browser/ResponsiveViewportCoverageTest.php
@@ -3,16 +3,184 @@
 namespace Tests\Browser;
 
 use App\Modules\Lyrics\Documents\Format;
+use App\Modules\Authentication\Models\User;
+use App\Modules\Lyrics\Models\Track;
+use App\Modules\Albums\Models\Album;
+use App\Modules\Reciters\Models\Reciter;
 use Laravel\Dusk\Browser;
 use Tests\DuskTestCase;
 use Throwable;
 
 class ResponsiveViewportCoverageTest extends DuskTestCase
 {
+    private const VIEWPORTS = [
+        'desktop' => [1440, 900],
+        'tablet' => [1024, 768],
+        'mobile' => [375, 812],
+    ];
+
     /**
      * @throws Throwable
      */
-    public function test_critical_pages_render_across_responsive_viewports(): void
+    public function test_home_page_responsive(): void
+    {
+        $this->assertRouteResponsive('/', 'Trending This Month');
+    }
+
+    /** @throws Throwable */
+    public function test_library_landing_page_responsive(): void
+    {
+        $this->assertRouteResponsive('/library', 'Welcome to your library');
+    }
+
+    /** @throws Throwable */
+    public function test_about_page_responsive(): void
+    {
+        $this->assertRouteResponsive('/about', 'The Journey');
+    }
+
+    /** @throws Throwable */
+    public function test_reciters_page_responsive(): void
+    {
+        $this->assertRouteResponsive('/reciters', 'Reciters');
+    }
+
+    /** @throws Throwable */
+    public function test_reciter_profile_page_responsive(): void
+    {
+        $fixtures = $this->createFixtures();
+        $this->assertRouteResponsive("/reciters/{$fixtures['reciter']->slug}", $fixtures['reciter']->name);
+    }
+
+    /** @throws Throwable */
+    public function test_album_page_responsive(): void
+    {
+        $fixtures = $this->createFixtures();
+        $this->assertRouteResponsive(
+            "/reciters/{$fixtures['reciter']->slug}/albums/{$fixtures['album']->year}",
+            $fixtures['album']->title
+        );
+    }
+
+    /** @throws Throwable */
+    public function test_track_page_responsive(): void
+    {
+        $fixtures = $this->createFixtures();
+        $path = "/reciters/{$fixtures['reciter']->slug}/albums/{$fixtures['album']->year}/tracks/{$fixtures['track']->slug}";
+        $this->browse(function (Browser $browser) use ($path, $fixtures) {
+            foreach (self::VIEWPORTS as $label => [$width, $height]) {
+                $browser->resize($width, $height)
+                    ->loginAs($fixtures['contributor'])
+                    ->visit($path)
+                    ->waitForText($fixtures['track']->title, 10)
+                    ->assertPresent('.bar__actions--overflow [dusk="edit-draft-lyrics-button"]')
+                    ->assertPresent('[dusk="lyrics-card"]');
+
+                $this->assertNoHorizontalOverflow($browser, $label, $path);
+            }
+        });
+    }
+
+    /** @throws Throwable */
+    public function test_print_lyrics_page_responsive(): void
+    {
+        $fixtures = $this->createFixtures();
+        $this->assertRouteResponsive(
+            "/print/{$fixtures['reciter']->slug}/{$fixtures['album']->year}/{$fixtures['track']->slug}",
+            $fixtures['track']->title
+        );
+    }
+
+    /** @throws Throwable */
+    public function test_library_home_page_responsive_for_contributor(): void
+    {
+        $fixtures = $this->createFixtures();
+        $this->browse(function (Browser $browser) use ($fixtures) {
+            foreach (self::VIEWPORTS as $label => [$width, $height]) {
+                $browser->resize($width, $height)
+                    ->loginAs($fixtures['contributor'])
+                    ->visit('/library/home')
+                    ->waitForText('Recently Saved Nawhas', 10)
+                    ->assertSee('Recently Saved Nawhas');
+
+                $this->assertNoHorizontalOverflow($browser, $label, '/library/home');
+            }
+        });
+    }
+
+    /** @throws Throwable */
+    public function test_library_tracks_page_responsive_for_contributor(): void
+    {
+        $fixtures = $this->createFixtures();
+        $this->browse(function (Browser $browser) use ($fixtures) {
+            foreach (self::VIEWPORTS as $label => [$width, $height]) {
+                $browser->resize($width, $height)
+                    ->loginAs($fixtures['contributor'])
+                    ->visit('/library/tracks')
+                    ->waitForText('Saved Nawhas', 10)
+                    ->assertSee('Saved Nawhas')
+                    ->assertSee($fixtures['track']->title);
+
+                $this->assertNoHorizontalOverflow($browser, $label, '/library/tracks');
+            }
+        });
+    }
+
+    /** @throws Throwable */
+    public function test_draft_lyrics_page_responsive_for_moderator(): void
+    {
+        $fixtures = $this->createFixtures();
+        $this->browse(function (Browser $browser) use ($fixtures) {
+            foreach (self::VIEWPORTS as $label => [$width, $height]) {
+                $browser->resize($width, $height)
+                    ->loginAs($fixtures['moderator'])
+                    ->visit('/moderator/drafts/lyrics')
+                    ->waitForText('Draft Lyrics', 10)
+                    ->assertSee('Draft Lyrics');
+
+                $this->assertNoHorizontalOverflow($browser, $label, '/moderator/drafts/lyrics');
+            }
+        });
+    }
+
+    /** @throws Throwable */
+    public function test_revisions_page_responsive_for_moderator(): void
+    {
+        $fixtures = $this->createFixtures();
+        $this->browse(function (Browser $browser) use ($fixtures) {
+            foreach (self::VIEWPORTS as $label => [$width, $height]) {
+                $browser->resize($width, $height)
+                    ->loginAs($fixtures['moderator'])
+                    ->visit('/moderator/revisions')
+                    ->waitForText('Revision History', 10)
+                    ->assertSee('Revision History');
+
+                $this->assertNoHorizontalOverflow($browser, $label, '/moderator/revisions');
+            }
+        });
+    }
+
+    /**
+     * @throws Throwable
+     */
+    private function assertRouteResponsive(string $path, string $expectedText): void
+    {
+        $this->browse(function (Browser $browser) use ($path, $expectedText) {
+            foreach (self::VIEWPORTS as $label => [$width, $height]) {
+                $browser->resize($width, $height)
+                    ->visit($path)
+                    ->waitForText($expectedText, 10)
+                    ->assertSee($expectedText);
+
+                $this->assertNoHorizontalOverflow($browser, $label, $path);
+            }
+        });
+    }
+
+    /**
+     * @return array{contributor: User, moderator: User, reciter: Reciter, album: Album, track: Track}
+     */
+    private function createFixtures(): array
     {
         $contributor = $this->getUserFactory()->contributor(['password' => 'secret']);
         $moderator = $this->getUserFactory()->moderator(['password' => 'secret']);
@@ -34,72 +202,13 @@ class ResponsiveViewportCoverageTest extends DuskTestCase
 
         $contributor->savedTracks()->attach($track->id, ['created_at' => now()]);
 
-        $viewports = [
-            'desktop' => [1440, 900],
-            'tablet' => [1024, 768],
-            'mobile' => [375, 812],
+        return [
+            'contributor' => $contributor,
+            'moderator' => $moderator,
+            'reciter' => $reciter,
+            'album' => $album,
+            'track' => $track,
         ];
-
-        $publicPages = [
-            '/' => 'Trending This Month',
-            '/library' => 'Welcome to your library',
-            '/about' => 'The Journey',
-            '/reciters' => 'Reciters',
-            "/reciters/{$reciter->slug}" => $reciter->name,
-            "/reciters/{$reciter->slug}/albums/{$album->year}" => $album->title,
-            "/reciters/{$reciter->slug}/albums/{$album->year}/tracks/{$track->slug}" => $track->title,
-            "/print/{$reciter->slug}/{$album->year}/{$track->slug}" => $track->title,
-        ];
-
-        $this->browse(function (Browser $browser) use ($viewports, $publicPages, $contributor, $moderator, $track) {
-            foreach ($viewports as $label => [$width, $height]) {
-                $browser->resize($width, $height);
-
-                foreach ($publicPages as $path => $expectedText) {
-                    $browser->visit($path)
-                        ->waitForText($expectedText, 10)
-                        ->assertSee($expectedText);
-
-                    $this->assertNoHorizontalOverflow($browser, $label, $path);
-                }
-
-                $browser->logout();
-                $this->loginViaUi($browser, $contributor, 'secret');
-
-                $browser->visit('/library/home')
-                    ->waitForText('Recently Saved Nawhas', 10)
-                    ->assertSee('Recently Saved Nawhas');
-                $this->assertNoHorizontalOverflow($browser, $label, '/library/home');
-
-                $browser->visit('/library/tracks')
-                    ->waitForText('Saved Nawhas', 10)
-                    ->assertSee('Saved Nawhas')
-                    ->assertSee($track->title);
-                $this->assertNoHorizontalOverflow($browser, $label, '/library/tracks');
-
-                $trackPath = "/reciters/{$track->reciter->slug}/albums/{$track->album->year}/tracks/{$track->slug}";
-                $browser->visit($trackPath)
-                    ->waitForText($track->title, 10)
-                    ->assertPresent('.bar__actions--overflow [dusk="edit-draft-lyrics-button"]')
-                    ->assertPresent('[dusk="lyrics-card"]');
-                $this->assertNoHorizontalOverflow($browser, $label, $trackPath);
-
-                $browser->logout();
-                $this->loginViaUi($browser, $moderator, 'secret');
-
-                $browser->visit('/moderator/drafts/lyrics')
-                    ->waitForText('Draft Lyrics', 10)
-                    ->assertSee('Draft Lyrics');
-                $this->assertNoHorizontalOverflow($browser, $label, '/moderator/drafts/lyrics');
-
-                $browser->visit('/moderator/revisions')
-                    ->waitForText('Revision History', 10)
-                    ->assertSee('Revision History');
-                $this->assertNoHorizontalOverflow($browser, $label, '/moderator/revisions');
-
-                $browser->logout();
-            }
-        });
     }
 
     private function assertNoHorizontalOverflow(Browser $browser, string $viewportLabel, string $path): void

--- a/api/tests/DuskTestCase.php
+++ b/api/tests/DuskTestCase.php
@@ -96,7 +96,7 @@ abstract class DuskTestCase extends BaseTestCase
         $browser->visit('/')
             ->waitFor('@user-menu__avatar', seconds: 10)
             ->click('@user-menu__avatar')
-            ->waitFor('@user-menu__login-button')
+            ->waitFor('@user-menu__login-button', seconds: 10)
             ->click('@user-menu__login-button')
             ->waitFor('.auth-dialog')
             ->type('.auth-dialog input[type=email]', $user->email)

--- a/api/tests/DuskTestCase.php
+++ b/api/tests/DuskTestCase.php
@@ -96,7 +96,7 @@ abstract class DuskTestCase extends BaseTestCase
         $browser->visit('/')
             ->waitFor('@user-menu__avatar', seconds: 10)
             ->click('@user-menu__avatar')
-            ->waitFor('@user-menu__login-button', seconds: 10)
+            ->waitFor('@user-menu__login-button', seconds: 20)
             ->click('@user-menu__login-button')
             ->waitFor('.auth-dialog')
             ->type('.auth-dialog input[type=email]', $user->email)

--- a/nuxt/components/edit/EditDraftLyrics.vue
+++ b/nuxt/components/edit/EditDraftLyrics.vue
@@ -14,6 +14,7 @@
         color="primary"
         rounded
         dark
+        dusk="edit-draft-lyrics-cta"
         @click="handleDialog"
       >
         {{ cta }}
@@ -22,6 +23,7 @@
         v-else
         icon
         dark
+        dusk="edit-draft-lyrics-button"
         @click="handleDialog"
       >
         <v-icon>lyrics</v-icon>
@@ -34,6 +36,7 @@
       >
         <v-btn
           icon
+          dusk="edit-draft-lyrics-close"
           @click="closeDialog"
         >
           <v-icon>close</v-icon>


### PR DESCRIPTION
## Summary
- add a new Dusk browser test that validates `/`, `/library`, and `/about` at desktop, tablet, and mobile viewport sizes
- assert page-specific key content renders at each viewport
- assert there is no horizontal overflow on those critical pages to catch responsive layout regressions

## Test plan
- [x] `./dev dusk tests/Browser/ResponsiveViewportCoverageTest.php`

Made with [Cursor](https://cursor.com)