### PR TITLE
feat(nuxt): Latest Stories section (reapply legacy PR #179)

### DIFF
--- a/nuxt/components/stories/StoryCard.vue
+++ b/nuxt/components/stories/StoryCard.vue
@@ -1,0 +1,55 @@
+<template>
+  <v-card class="story" :to="route">
+    <v-img :src="story.image" height="200px" />
+    <v-card-text class="text--primary">
+      <h5 class="overline">
+        {{ story.date | date }}
+      </h5>
+      <h3 class="title">
+        {{ story.title }}
+      </h3>
+      <p class="body" v-html="story.body" />
+    </v-card-text>
+    <v-card-actions class="actions">
+      <v-btn text color="primary">
+        Read more
+      </v-btn>
+    </v-card-actions>
+  </v-card>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue } from 'nuxt-property-decorator';
+import { RawLocation } from 'vue-router';
+import { Story } from '@/entities/story';
+
+@Component
+export default class StoryCard extends Vue {
+  @Prop({ type: Object, required: true }) private readonly story!: Story;
+
+  get route(): RawLocation {
+    return {
+      name: 'stories.show',
+      params: {
+        date: this.story.date,
+        story: this.story.slug,
+      },
+    };
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.story .body {
+  --line-height: 1.2rem;
+  --max-lines: 3;
+  line-height: var(--line-height);
+  height: calc(var(--line-height) * var(--max-lines));
+  overflow: hidden;
+  opacity: 0.65;
+  margin: 6px 0 0;
+}
+.story .actions {
+  padding-top: 0;
+}
+</style>

--- a/nuxt/components/stories/StoryCardGrid.vue
+++ b/nuxt/components/stories/StoryCardGrid.vue
@@ -1,0 +1,23 @@
+<template>
+  <v-row>
+    <v-col v-for="(story, index) in stories" :key="index" md="4">
+      <story-card :story="story" />
+    </v-col>
+  </v-row>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from 'nuxt-property-decorator';
+import StoryCard from '@/components/stories/StoryCard.vue';
+
+@Component({
+  components: {
+    StoryCard,
+  },
+})
+export default class StoryCardGrid extends Vue {
+  get stories() {
+    return this.$store.getters['stories/stories'];
+  }
+}
+</script>

--- a/nuxt/data/stories.ts
+++ b/nuxt/data/stories.ts
@@ -1,0 +1,85 @@
+import { Story } from '@/entities/story';
+
+export const stories: Array<Story> = [
+  {
+    date: '2020-05-05',
+    slug: 'covid-19-relief-fund',
+    image: 'https://nawhas.s3.us-east-2.amazonaws.com/stories/alayn-charity.jpg',
+    title: 'Donate to Al-Ayn\'s COVID-19 Relief Fund',
+    body: `
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc placerat laoreet turpis id blandit. 
+      Aliquam ut eros id arcu semper placerat quis non est. Ut vitae tellus quis est accumsan mollis. 
+      Vivamus id diam ipsum. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere 
+      cubilia curae; Nam convallis, risus in interdum ultrices, eros turpis posuere lacus, vitae blandit
+      urna sem ac lectus. Duis id dapibus erat, ut tincidunt magna. Duis consectetur vulputate semper. 
+      Donec bibendum ligula eu arcu molestie, ut congue elit tempor. Quisque diam magna, sodales nec ante
+      vitae, eleifend tempus sapien. Praesent aliquet rutrum tincidunt. Phasellus sagittis sapien ut elit
+      blandit lobortis. Integer velit nunc, sodales nec porttitor at, placerat in arcu. Nunc non rutrum
+      sapien. Curabitur auctor scelerisque ligula, et malesuada turpis elementum et.
+      
+      Morbi gravida sodales leo, id sagittis nisi convallis vitae. Vivamus tempor leo at nulla blandit,
+      eget accumsan ipsum tincidunt. Vivamus pellentesque rhoncus malesuada. Phasellus interdum dolor
+      felis, id laoreet ligula venenatis vitae. Proin nibh diam, tristique nec est ut, semper faucibus
+      odio. Sed consectetur dolor sed sagittis accumsan. Proin finibus leo nec rutrum tristique. In ut
+      laoreet elit, non molestie urna. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices
+      posuere cubilia curae; Morbi et diam fermentum, euismod ipsum eget, mattis ex. Phasellus in dapibus
+      libero. Quisque vestibulum pretium felis, vel consequat risus vehicula a. Fusce malesuada imperdiet
+      tristique. Vivamus volutpat tortor eget hendrerit accumsan. Mauris vitae cursus sem, vel tempor
+      augue.
+    `,
+  },
+  {
+    date: '2020-05-05',
+    image: 'https://nawhas.s3.us-east-2.amazonaws.com/stories/alayn-charity.jpg',
+    title: 'Donate to Al-Ayn\'s COVID-19 Relief Fund',
+    slug: 'covid-19-relief-fund',
+    body: `
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc placerat laoreet turpis id blandit. 
+      Aliquam ut eros id arcu semper placerat quis non est. Ut vitae tellus quis est accumsan mollis. 
+      Vivamus id diam ipsum. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere 
+      cubilia curae; Nam convallis, risus in interdum ultrices, eros turpis posuere lacus, vitae blandit
+      urna sem ac lectus. Duis id dapibus erat, ut tincidunt magna. Duis consectetur vulputate semper. 
+      Donec bibendum ligula eu arcu molestie, ut congue elit tempor. Quisque diam magna, sodales nec ante
+      vitae, eleifend tempus sapien. Praesent aliquet rutrum tincidunt. Phasellus sagittis sapien ut elit
+      blandit lobortis. Integer velit nunc, sodales nec porttitor at, placerat in arcu. Nunc non rutrum
+      sapien. Curabitur auctor scelerisque ligula, et malesuada turpis elementum et.
+      
+      Morbi gravida sodales leo, id sagittis nisi convallis vitae. Vivamus tempor leo at nulla blandit,
+      eget accumsan ipsum tincidunt. Vivamus pellentesque rhoncus malesuada. Phasellus interdum dolor
+      felis, id laoreet ligula venenatis vitae. Proin nibh diam, tristique nec est ut, semper faucibus
+      odio. Sed consectetur dolor sed sagittis accumsan. Proin finibus leo nec rutrum tristique. In ut
+      laoreet elit, non molestie urna. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices
+      posuere cubilia curae; Morbi et diam fermentum, euismod ipsum eget, mattis ex. Phasellus in dapibus
+      libero. Quisque vestibulum pretium felis, vel consequat risus vehicula a. Fusce malesuada imperdiet
+      tristique. Vivamus volutpat tortor eget hendrerit accumsan. Mauris vitae cursus sem, vel tempor
+      augue.
+    `,
+  },
+  {
+    date: '2020-05-05',
+    image: 'https://nawhas.s3.us-east-2.amazonaws.com/stories/alayn-charity.jpg',
+    title: 'Donate to Al-Ayn\'s COVID-19 Relief Fund',
+    slug: 'covid-19-relief-fund',
+    body: `
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc placerat laoreet turpis id blandit. 
+      Aliquam ut eros id arcu semper placerat quis non est. Ut vitae tellus quis est accumsan mollis. 
+      Vivamus id diam ipsum. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere 
+      cubilia curae; Nam convallis, risus in interdum ultrices, eros turpis posuere lacus, vitae blandit
+      urna sem ac lectus. Duis id dapibus erat, ut tincidunt magna. Duis consectetur vulputate semper. 
+      Donec bibendum ligula eu arcu molestie, ut congue elit tempor. Quisque diam magna, sodales nec ante
+      vitae, eleifend tempus sapien. Praesent aliquet rutrum tincidunt. Phasellus sagittis sapien ut elit
+      blandit lobortis. Integer velit nunc, sodales nec porttitor at, placerat in arcu. Nunc non rutrum
+      sapien. Curabitur auctor scelerisque ligula, et malesuada turpis elementum et.
+      
+      Morbi gravida sodales leo, id sagittis nisi convallis vitae. Vivamus tempor leo at nulla blandit,
+      eget accumsan ipsum tincidunt. Vivamus pellentesque rhoncus malesuada. Phasellus interdum dolor
+      felis, id laoreet ligula venenatis vitae. Proin nibh diam, tristique nec est ut, semper faucibus
+      odio. Sed consectetur dolor sed sagittis accumsan. Proin finibus leo nec rutrum tristique. In ut
+      laoreet elit, non molestie urna. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices
+      posuere cubilia curae; Morbi et diam fermentum, euismod ipsum eget, mattis ex. Phasellus in dapibus
+      libero. Quisque vestibulum pretium felis, vel consequat risus vehicula a. Fusce malesuada imperdiet
+      tristique. Vivamus volutpat tortor eget hendrerit accumsan. Mauris vitae cursus sem, vel tempor
+      augue.
+    `,
+  },
+];

--- a/nuxt/entities/story.ts
+++ b/nuxt/entities/story.ts
@@ -1,0 +1,7 @@
+export interface Story {
+  date: string;
+  image: string;
+  slug: string;
+  title: string;
+  body: string;
+}

--- a/nuxt/filters/date.ts
+++ b/nuxt/filters/date.ts
@@ -7,3 +7,8 @@ export function relative(date: moment.MomentInput) {
 export function local(date: moment.MomentInput) {
   return moment.utc(date).format('LLL');
 }
+
+/** Long date (e.g. May 5, 2020) for story cards — matches legacy `web` `date` filter default. */
+export function calendarDate(value: moment.MomentInput, format = 'LL'): string {
+  return moment.utc(value).format(format);
+}

--- a/nuxt/filters/index.ts
+++ b/nuxt/filters/index.ts
@@ -2,6 +2,8 @@
 import Vue from 'vue';
 import _ from 'lodash';
 import { pluralize } from '@/filters/string';
+import { calendarDate } from '@/filters/date';
 
 Vue.filter('pluralize', pluralize);
 Vue.filter('startCase', _.startCase);
+Vue.filter('date', calendarDate);

--- a/nuxt/pages/HomePage.vue
+++ b/nuxt/pages/HomePage.vue
@@ -35,6 +35,13 @@
     </v-container>
 
     <v-container class="app__section">
+      <h5 class="section__title">
+        Latest Stories
+      </h5>
+      <story-card-grid />
+    </v-container>
+
+    <v-container class="app__section">
       <div class="section__title mt-6">
         <div>
           <v-icon>favorite</v-icon> Recently Saved Nawhas
@@ -116,6 +123,7 @@ import { Track } from '@/entities/track';
 import { ReciterIncludes } from '@/api/reciters';
 import { TrackIncludes } from '@/api/tracks';
 import SavedTracksEmptyState from '@/components/library/SavedTracksEmptyState.vue';
+import StoryCardGrid from '@/components/stories/StoryCardGrid.vue';
 
 const POPULAR_ENTITIES_LIMIT = 6;
 
@@ -128,6 +136,7 @@ interface Data {
 
 export default Vue.extend({
   components: {
+    StoryCardGrid,
     SavedTracksEmptyState,
     TrackList,
     HeroBanner,

--- a/nuxt/pages/StoryPage.vue
+++ b/nuxt/pages/StoryPage.vue
@@ -1,0 +1,58 @@
+<router>
+  path: /stories/:date/:story
+  name: "stories.show"
+</router>
+
+<template>
+  <div class="story-page app__section">
+    <v-container v-if="story">
+      <v-btn text class="mb-4" to="/" exact>
+        <v-icon left>
+          chevron_left
+        </v-icon>
+        Home
+      </v-btn>
+      <h5 class="overline">
+        {{ story.date | date }}
+      </h5>
+      <h1 class="display-1 mb-4">
+        {{ story.title }}
+      </h1>
+      <v-img :src="story.image" max-height="360px" contain class="mb-6" />
+      <div class="story-page__body body-1">
+        {{ story.body }}
+      </div>
+    </v-container>
+    <v-container v-else>
+      <h1 class="headline">
+        Story
+      </h1>
+      <p class="body-1">
+        This story could not be found.
+      </p>
+      <v-btn color="primary" to="/" exact>
+        Back to home
+      </v-btn>
+    </v-container>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+import { Story } from '@/entities/story';
+
+export default Vue.extend({
+  computed: {
+    story(): Story | undefined {
+      const slug = this.$route.params.story;
+      return this.$store.getters['stories/story'](slug);
+    },
+  },
+});
+</script>
+
+<style lang="scss" scoped>
+.story-page__body {
+  white-space: pre-line;
+}
+</style>

--- a/nuxt/store/index.ts
+++ b/nuxt/store/index.ts
@@ -12,4 +12,5 @@ export type RootState = {
   library: LibraryState,
   player: PlayerState,
   preferences: PreferencesState,
+  stories: import('@/store/stories').StoriesState,
 };

--- a/nuxt/store/stories.ts
+++ b/nuxt/store/stories.ts
@@ -1,0 +1,24 @@
+import { GetterTree } from 'vuex';
+import { Story } from '@/entities/story';
+import { stories as storyList } from '@/data/stories';
+
+export interface StoriesState {
+  stories: Array<Story>;
+}
+
+const state = (): StoriesState => ({
+  stories: storyList,
+});
+
+const getters: GetterTree<StoriesState, Record<string, unknown>> = {
+  stories(st): Array<Story> {
+    return st.stories;
+  },
+  story: (st) => (slug: string): Story | undefined => st.stories.find((s) => s.slug === slug),
+};
+
+export default {
+  namespaced: true,
+  state,
+  getters,
+};


### PR DESCRIPTION
## Summary

Ports the **Latest Stories** work from legacy PR [#179](https://github.com/nawhas/nawhas/pull/179) onto the current **Nuxt** app (`nuxt/` directory). The old PR targeted `web/`, which no longer exists on `master`.

## What changed

- Home: **Latest Stories** grid after Trending
- Static `nuxt/data/stories.ts` (same placeholder content as the legacy PR)
- Vuex `stories` module + `Story` entity
- `StoryCard` / `StoryCardGrid` components
- Route `/stories/:date/:story` (`StoryPage.vue`) with readable story body (legacy PR had a stub detail view)
- Global `| date` filter (long date, `LL`)

## Tracking

Paperclip: **NAW-29** — decide merge vs close vs follow-up after review.

Co-Authored-By: Paperclip <noreply@paperclip.ing>
